### PR TITLE
Add ecs parameters to rule

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -32,9 +32,19 @@ func TestLoadConfig(t *testing.T) {
 				ScheduleExpression: "cron(0 0 * * ? *)",
 				Disabled:           false,
 				Target: &Target{
-					TargetID:       "",
-					TaskDefinition: "task1",
-					TaskCount:      0,
+					TargetID:        "",
+					TaskDefinition:  "task1",
+					TaskCount:       0,
+					Group:           "xxx",
+					PlatformVersion: "1.4.0",
+					LaunchType:      "FARGATE",
+					NetworkConfiguration: &NetworkConfiguration{
+						AwsVpcConfiguration: &AwsVpcConfiguration{
+							Subnets:        []string{"subnet-01234567", "subnet-12345678"},
+							SecurityGroups: []string{"sg-11111111", "sg-99999999"},
+							AssinPublicIP:  "ENABLED",
+						},
+					},
 					ContainerOverrides: []*ContainerOverride{
 						{
 							Name: "container1",

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -6,6 +6,18 @@ rules:
   description: hoge description
   scheduleExpression: cron(0 0 * * ? *)
   taskDefinition: task1
+  group: xxx
+  platform_version: 1.4.0
+  launch_type: FARGATE
+  network_configuration:
+    aws_vpc_configuration:
+      subnets:
+      - subnet-01234567
+      - subnet-12345678
+      security_groups:
+      - sg-11111111
+      - sg-99999999
+      assign_public_ip: ENABLED
   containerOverrides:
   - name: container1
     command: ["subcmd", "argument"]


### PR DESCRIPTION
Hi.

I hope to use ecschedule on my production workload, but some ECS parameters are not supported.
Add support to Group, LaunchType, PlatformVersion and NetworkConfiguration into ECS parameters.