### PR TITLE
enable shared config state

### DIFF
--- a/ecsched.go
+++ b/ecsched.go
@@ -37,7 +37,9 @@ func Run(argv []string, outStream, errStream io.Writer) error {
 	if *ver {
 		return printVersion(outStream)
 	}
-	sess, err := session.NewSession()
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Thanks for making greate tool.

I want to use ecschedule with ecspresso in my production environment. But, ecschedule doesn't support shared config though ecspresso do.
This is a little bit comfusing in local development.
If you merge this PR,  ecspresso will load a config from ~/.aws/config.

