### PR TITLE
Add action.yml for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ cluster: clusterName
 % go get github.com/Songmu/ecschedule/cmd/ecschedule
 ```
 
+### GitHub Actions
+
+Action Songmu/ecschedule@main installs ecschedule binary for Linux into /usr/local/bin. This action runs install only.
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Songmu/ecschedule@main
+        with:
+          version: v0.3.1
+      - run: |
+          ecschedule -conf ecschedule.yaml apply -all
+```
+
 ## Quick Start
 
 ### dump configuration YAML

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,15 @@
+inputs:
+  version:
+    description: "A version to install ecschedule"
+    default: "v0.3.1"
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        DIRNAME=ecschedule_${{ inputs.version }}_linux_amd64
+        cd /tmp
+        curl -sLO https://github.com/Songmu/ecschedule/releases/download/${{ inputs.version }}/${DIRNAME}.tar.gz
+        tar zxvf ${DIRNAME}.tar.gz
+        sudo mv ${DIRNAME}/ecschedule /usr/local/bin/ecschedule
+        rm -rf ${DIRNAME} ${DIRNAME}.zip
+      shell: bash


### PR DESCRIPTION
I added `action.yml` for GitHub Actions, which is inspired by [that of ecspresso](https://github.com/kayac/ecspresso/blob/v0/action.yml).

I verified it works properly with [mokichi/ecschedule-install-action-sample](https://github.com/mokichi/ecschedule-install-action-sample/runs/2334329996).