### PR TITLE
Add procedure of execute `run` subcommand to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Before you apply it, you can check the diff in the following way.
 % ecschedule -conf ecschedule.yaml diff -rule $ruleName
 ```
 
+### run rule
+
+Execute `run` subcommand when want execute arbitrary timing.
+
+```console
+% ecschedule -conf ecschedule.yaml run -rule $ruleName
+```
+
 ## Functions
 
 You can use following functions in the configuration file.


### PR DESCRIPTION
update readme for about `run` subcommand.

```console
$ ecschedule -help 
Usage of ecschedule (v0.3.1 rev:13906aa):
  -conf string
        configuration
  -version
        display version

Commands:
  apply  apply the rule
  dump   dump tasks
  run    run the rule
  diff   diff of the rule with remote
```

I'm making use of this tool.
Thanks.