### PR TITLE
added task definition validation.

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -265,9 +265,23 @@ func (r *Rule) validateEnv() error {
 	return nil
 }
 
+func (r *Rule) validateTaskDefinition(sess *session.Session) error {
+	svc := ecs.New(sess, &aws.Config{Region: aws.String(r.Region)})
+	input := &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(r.Target.TaskDefinition),
+	}
+	if _, err := svc.DescribeTaskDefinition(input); err != nil {
+		return fmt.Errorf("task definition %s is not defined: %s", r.Target.TaskDefinition, err.Error())
+	}
+	return nil
+}
+
 // Apply the rule
 func (r *Rule) Apply(ctx context.Context, sess *session.Session, dryRun bool) error {
 	if err := r.validateEnv(); err != nil {
+		return err
+	}
+	if err := r.validateTaskDefinition(sess); err != nil {
 		return err
 	}
 	svc := cloudwatchevents.New(sess, &aws.Config{Region: aws.String(r.Region)})


### PR DESCRIPTION
Added validation for Task Definition.

## Background

Scheduled Task is fail if specified not defined Task Definition or Revision. And it is need to effort for catch this problem. (no ECS error, no Task log..., see CloudWatchMetrics FailedInvocations)

ecschedule is able to set undefined Task Definition and Revision. On AWS management console, Task Definition is able to select only from defined Task Definitions and Revisions. However Scheduled Task API(CloudWatchEvent) does not check defined Task Definition.

## Solution

If specified undefined Task Definition and Revision, then error and exit command.

sample validation error message
```
[ecschedule] applying the rule "ScheduleTask1"
[ecschedule] 💢 task definition sample-task:5 is not defined: ClientException: Unable to describe task definition.
```
(`ClientException: Unable to describe task definition.` is return from ECS DescribeTaskDefinition API)

### Breaking change in specific case.

I chose default do validate, because I guess almost case is not affected.

It will not be setable ScheduledTask that use undefined Task Definition after this change. Would you like to need Opt-Out option? (ex. `-without-taskdef-validation`) or change to Opt-In option? (ex. `-validate-task-definition`)