### PR TITLE
support deadletter config

### DIFF
--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -95,7 +95,7 @@ var cmdDump = &runnerImpl{
 				taskDefArnPrefix: fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/", *region, accountID),
 				roleArnPrefix:    roleArnPrefix,
 				roleArn:          fmt.Sprintf("%s%s", roleArnPrefix, *role),
-				sqsArnPrefix:     fmt.Sprintf("arn:aws:sqs:%s:%s", *region, accountID),
+				sqsArnPrefix:     fmt.Sprintf("arn:aws:sqs:%s:%s:", *region, accountID),
 			}
 		)
 		for _, r := range remoteRules {

--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -95,6 +95,7 @@ var cmdDump = &runnerImpl{
 				taskDefArnPrefix: fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/", *region, accountID),
 				roleArnPrefix:    roleArnPrefix,
 				roleArn:          fmt.Sprintf("%s%s", roleArnPrefix, *role),
+				sqsArnPrefix:     fmt.Sprintf("arn:aws:sqs:%s:%s", *region, accountID),
 			}
 		)
 		for _, r := range remoteRules {

--- a/config_test.go
+++ b/config_test.go
@@ -57,6 +57,9 @@ func TestLoadConfig(t *testing.T) {
 							},
 						},
 					},
+					DeadLetterConfig: &DeadLetterConfig{
+						Sqs: "queue1",
+					},
 					Role: "ecsEventsRole",
 				},
 				BaseConfig: &BaseConfig{

--- a/rule.go
+++ b/rule.go
@@ -179,14 +179,16 @@ func (r *Rule) ecsParameters() *cloudwatchevents.EcsParameters {
 }
 
 func (r *Rule) deadLetterConfigParameters() *cloudwatchevents.DeadLetterConfig {
-	p := cloudwatchevents.DeadLetterConfig{}
-
 	ta := r.Target
+
 	if dlc := ta.DeadLetterConfig; dlc != nil {
-		p.Arn = aws.String(dlc.sqsArn(r))
+		arn := dlc.sqsArn(r)
+		return &cloudwatchevents.DeadLetterConfig{
+			Arn: aws.String(arn),
+		}
 	}
 
-	return &p
+	return nil
 }
 
 func (r *Rule) mergeBaseConfig(bc *BaseConfig, role string) {

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -11,8 +11,8 @@ import (
 )
 
 type ruleGetter struct {
-	svc                                                                 *cloudwatchevents.CloudWatchEvents
-	clusterArn, ruleArnPrefix, taskDefArnPrefix, roleArnPrefix, roleArn string
+	svc                                                                               *cloudwatchevents.CloudWatchEvents
+	clusterArn, ruleArnPrefix, taskDefArnPrefix, roleArnPrefix, roleArn, sqsArnPrefix string
 }
 
 func (rg *ruleGetter) getRule(ctx context.Context, r *cloudwatchevents.Rule) (*Rule, error) {
@@ -90,7 +90,7 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cloudwatchevents.Rule) (*R
 
 		if dlc := t.DeadLetterConfig; dlc != nil {
 			target.DeadLetterConfig = &DeadLetterConfig{
-				Sqs: strings.TrimPrefix(*dlc.Arn, rg.roleArnPrefix),
+				Sqs: strings.TrimPrefix(*dlc.Arn, rg.sqsArnPrefix),
 			}
 		}
 	}

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -87,6 +87,12 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cloudwatchevents.Rule) (*R
 		}
 		target.ContainerOverrides = contOverrides
 		targets = append(targets, target)
+
+		if dlc := t.DeadLetterConfig; dlc != nil {
+			target.DeadLetterConfig = &DeadLetterConfig{
+				Sqs: strings.TrimPrefix(*dlc.Arn, rg.roleArnPrefix),
+			}
+		}
 	}
 	var desc string
 	if r.Description != nil {

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -23,3 +23,5 @@ rules:
     command: ["subcmd", "argument"]
     environment:
       HOGE_ENV: {{ env "DUMMY_HOGE_ENV" "HOGEGE" }}
+  dead_letter_config:
+    sqs: queue1


### PR DESCRIPTION
Hello,

I hope to use ecschedule on my production workload, but DeadLetter Config parameters are not supported.

https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-dlq.html

Add support to DeadLetterConfig into Target Parameter.

I would appreciate your review.

Thank you.