### PR TITLE
feat: add propagateTags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ rules:
       HOGE_ENV: {{ env "DUMMY_HOGE_ENV" "HOGEGE" }}
   dead_letter_config:
     sqs: queue1
+  propagateTags: TASK_DEFINITION
 plugins:
 - name: tfstate
   config:

--- a/config_test.go
+++ b/config_test.go
@@ -62,6 +62,7 @@ func TestLoadConfig(t *testing.T) {
 					DeadLetterConfig: &DeadLetterConfig{
 						Sqs: "queue1",
 					},
+					PropagateTags: "TASK_DEFINITION",
 					Role: "ecsEventsRole",
 				},
 				BaseConfig: &BaseConfig{

--- a/rule.go
+++ b/rule.go
@@ -40,6 +40,7 @@ type Target struct {
 	PlatformVersion      string                `yaml:"platform_version,omitempty"`
 	NetworkConfiguration *NetworkConfiguration `yaml:"network_configuration,omitempty"`
 	DeadLetterConfig     *DeadLetterConfig     `yaml:"dead_letter_config,omitempty"`
+	PropagateTags        string                `yaml:"propagateTags,omitempty"`
 }
 
 // ContainerOverride overrids container
@@ -171,6 +172,9 @@ func (r *Rule) ecsParameters() *cloudwatchevents.EcsParameters {
 	}
 	if ta.PlatformVersion != "" {
 		p.PlatformVersion = aws.String(ta.PlatformVersion)
+	}
+	if ta.PropagateTags != "" {
+		p.PropagateTags = aws.String(ta.PropagateTags)
 	}
 	if nc := ta.NetworkConfiguration; nc != nil {
 		p.NetworkConfiguration = nc.ecsParameters()
@@ -412,6 +416,7 @@ func (r *Rule) Run(ctx context.Context, sess *session.Session, noWait bool) erro
 			Count:                aws.Int64(r.taskCount()),
 			LaunchType:           aws.String(r.Target.LaunchType),
 			NetworkConfiguration: networkConfiguration,
+			PropagateTags:        aws.String(r.PropagateTags),
 		})
 	if err != nil {
 		return err

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -25,3 +25,4 @@ rules:
       HOGE_ENV: {{ env "DUMMY_HOGE_ENV" "HOGEGE" }}
   dead_letter_config:
     sqs: queue1
+  propagateTags: TASK_DEFINITION

--- a/testdata/sample2.yaml
+++ b/testdata/sample2.yaml
@@ -11,3 +11,4 @@ rules:
     command: ["subcmd", "argument"]
     environment:
       HOGE_ENV: {{ must_env "DUMMY_HOGE_ENV" }}
+  propagateTags: TASK_DEFINITION

--- a/testdata/sample3.yaml
+++ b/testdata/sample3.yaml
@@ -25,6 +25,7 @@ rules:
       HOGE_ENV: {{ env "DUMMY_HOGE_ENV" "HOGEGE" }}
   dead_letter_config:
     sqs: queue1
+  propagateTags: TASK_DEFINITION
 plugins:
 - name: tfstate
   config:


### PR DESCRIPTION
This option allows you to tag tasks. The only valid value is `TASK_DEFINITION`.