### PR TITLE
fix: allow undefined for PropagateTags

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -62,8 +64,8 @@ func TestLoadConfig(t *testing.T) {
 					DeadLetterConfig: &DeadLetterConfig{
 						Sqs: "queue1",
 					},
-					PropagateTags: "TASK_DEFINITION",
-					Role: "ecsEventsRole",
+					PropagateTags: aws.String("TASK_DEFINITION"),
+					Role:          "ecsEventsRole",
 				},
 				BaseConfig: &BaseConfig{
 					Region:    "us-east-1",
@@ -134,5 +136,23 @@ func TestLoadConfig_tfstate(t *testing.T) {
 	esg := []string{"sg-11111111", "sg-99999999"}
 	if !reflect.DeepEqual(asg, esg) {
 		t.Errorf("error shoud be %v, but: %v", asg, esg)
+	}
+}
+
+func TestLoadConfig_undefined(t *testing.T) {
+	path := "testdata/sample4.yaml"
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	c, err := LoadConfig(f, "337", path)
+	if err != nil {
+		t.Errorf("error shoud be nil, but: %s", err)
+	}
+
+	if c.Rules[0].PropagateTags != nil {
+		t.Errorf("error shoud be nil, but: %v", c.Rules[0].PropagateTags)
 	}
 }

--- a/rule.go
+++ b/rule.go
@@ -40,7 +40,7 @@ type Target struct {
 	PlatformVersion      string                `yaml:"platform_version,omitempty"`
 	NetworkConfiguration *NetworkConfiguration `yaml:"network_configuration,omitempty"`
 	DeadLetterConfig     *DeadLetterConfig     `yaml:"dead_letter_config,omitempty"`
-	PropagateTags        string                `yaml:"propagateTags,omitempty"`
+	PropagateTags        *string               `yaml:"propagateTags,omitempty"`
 }
 
 // ContainerOverride overrids container
@@ -172,9 +172,6 @@ func (r *Rule) ecsParameters() *cloudwatchevents.EcsParameters {
 	}
 	if ta.PlatformVersion != "" {
 		p.PlatformVersion = aws.String(ta.PlatformVersion)
-	}
-	if ta.PropagateTags != "" {
-		p.PropagateTags = aws.String(ta.PropagateTags)
 	}
 	if nc := ta.NetworkConfiguration; nc != nil {
 		p.NetworkConfiguration = nc.ecsParameters()
@@ -416,7 +413,7 @@ func (r *Rule) Run(ctx context.Context, sess *session.Session, noWait bool) erro
 			Count:                aws.Int64(r.taskCount()),
 			LaunchType:           aws.String(r.Target.LaunchType),
 			NetworkConfiguration: networkConfiguration,
-			PropagateTags:        aws.String(r.PropagateTags),
+			PropagateTags:        r.PropagateTags,
 		})
 	if err != nil {
 		return err

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -55,7 +55,7 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cloudwatchevents.Rule) (*R
 		target.Group = aws.StringValue(ecsParams.Group)
 		target.LaunchType = aws.StringValue(ecsParams.LaunchType)
 		target.PlatformVersion = aws.StringValue(ecsParams.PlatformVersion)
-		target.PropagateTags = aws.StringValue(t.EcsParameters.PropagateTags)
+		target.PropagateTags = t.EcsParameters.PropagateTags
 		if nc := ecsParams.NetworkConfiguration; nc != nil {
 			target.NetworkConfiguration = &NetworkConfiguration{
 				AwsVpcConfiguration: &AwsVpcConfiguration{

--- a/testdata/sample4.yaml
+++ b/testdata/sample4.yaml
@@ -1,0 +1,27 @@
+region: us-east-1
+cluster: api
+role: ecsEventsRole
+rules:
+- name: hoge-task-name
+  description: hoge description
+  scheduleExpression: cron(0 0 * * ? *)
+  taskDefinition: task1
+  group: xxx
+  platform_version: 1.4.0
+  launch_type: FARGATE
+  network_configuration:
+    aws_vpc_configuration:
+      subnets:
+      - subnet-01234567
+      - subnet-12345678
+      security_groups:
+      - sg-11111111
+      - sg-99999999
+      assign_public_ip: ENABLED
+  containerOverrides:
+  - name: container1
+    command: ["subcmd", "argument"]
+    environment:
+      HOGE_ENV: {{ env "DUMMY_HOGE_ENV" "HOGEGE" }}
+  dead_letter_config:
+    sqs: queue1


### PR DESCRIPTION
Error if `propagateTags` is undefined for v0.6.x.

```
[ecschedule] 💢 InvalidParameterException: Invalid value for propagateTags
```

use pointer for `propagateTags` so allow undefined.