### PR TITLE
fix a shell command to expand variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
   - run: |
       TEMP_PATH="$(mktemp -d)"
-      curl -sfL https://raw.githubusercontent.com/Songmu/ecschedule/main/install.sh | sh -s -- -b "$TEMP_PATH" "{{ inputs.version }}" 2>&1
+      curl -sfL https://raw.githubusercontent.com/Songmu/ecschedule/main/install.sh | sh -s -- -b "${TEMP_PATH}" "${{ inputs.version }}" 2>&1
       sudo mv ${TEMP_PATH}/ecschedule /usr/local/bin/ecschedule
       rm -rf ${TEMP_PATH}
     shell: bash


### PR DESCRIPTION
The latest main version of this action seems to be failing for variables expansion.

The following is the execution log in my repo.

```
  TEMP_PATH="$(mktemp -d)"
  curl -sfL https://raw.githubusercontent.com/Songmu/ecschedule/main/install.sh | sh -s -- -b "$TEMP_PATH" "{{ inputs.version }}" 2>&1
  sudo mv ${TEMP_PATH}/ecschedule /usr/local/bin/ecschedule
  rm -rf ${TEMP_PATH}
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    (omit)
Songmu/ecschedule info checking GitHub for tag '{{ inputs.version }}'
Songmu/ecschedule crit unable to find '{{ inputs.version }}' - use 'latest' or see https://github.com/Songmu/ecschedule/releases for details
```