### PR TITLE
Update version description "v0.3.1" to "v0.7.1" in  README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Songmu/ecschedule@main
         with:
-          version: v0.3.1
+          version: v0.7.1
       - run: |
           ecschedule -conf ecschedule.yaml apply -all
 ```


### PR DESCRIPTION
The version in the README(Github Actions section) was "v0.3.1", so I changed it to "v0.7.1".

Is it possible to set it to something like "latest"? 
If possible, it would be good to rewrite it to "latest".