### PR TITLE
feat: Adding a `-prune` option to remove Orphaned Rules.

### DIFF
--- a/event_bridge.go
+++ b/event_bridge.go
@@ -12,13 +12,13 @@ import (
 )
 
 type Query struct {
-	ResourceTypeFIlters []string `json:"ResourceTypeFilters"`
-	TagFilters 					[]TagFilter    `json:"TagFilters"`
+	ResourceTypeFIlters []string    `json:"ResourceTypeFilters"`
+	TagFilters          []TagFilter `json:"TagFilters"`
 }
 
 type TagFilter struct {
-	Key		  string   `json:"Key"`
-	Values	[]string `json:"Values"`
+	Key    string   `json:"Key"`
+	Values []string `json:"Values"`
 }
 
 // Extract the Rule associated with trackingId and extract those that are not included in ruleNames.
@@ -57,7 +57,7 @@ func listTrackedRules(ctx context.Context, sess *session.Session, trackingId str
 		ResourceTypeFIlters: []string{"AWS::Events::Rule"},
 		TagFilters: []TagFilter{
 			{
-				Key: "ecschedule:tracking-id",
+				Key:    "ecschedule:tracking-id",
 				Values: []string{trackingId},
 			},
 		},
@@ -69,7 +69,7 @@ func listTrackedRules(ctx context.Context, sess *session.Session, trackingId str
 
 	input := &resourcegroups.SearchResourcesInput{
 		ResourceQuery: &resourcegroups.ResourceQuery{
-			Type: aws.String(resourcegroups.QueryTypeTagFilters10),
+			Type:  aws.String(resourcegroups.QueryTypeTagFilters10),
 			Query: aws.String(string(queryBytes)),
 		},
 	}
@@ -85,7 +85,7 @@ func listTrackedRules(ctx context.Context, sess *session.Session, trackingId str
 	for _, identifier := range result.ResourceIdentifiers {
 		arn := *identifier.ResourceArn
 		arnElements := strings.Split(arn, "/")
-		ruleName := arnElements[len(arnElements) - 1]
+		ruleName := arnElements[len(arnElements)-1]
 		ruleNames = append(ruleNames, ruleName)
 	}
 

--- a/event_bridge.go
+++ b/event_bridge.go
@@ -1,0 +1,93 @@
+package ecschedule
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/resourcegroups"
+	"golang.org/x/exp/slices"
+)
+
+type Query struct {
+	ResourceTypeFIlters []string `json:"ResourceTypeFilters"`
+	TagFilters 					[]TagFilter    `json:"TagFilters"`
+}
+
+type TagFilter struct {
+	Key		  string   `json:"Key"`
+	Values	[]string `json:"Values"`
+}
+
+// Extract the Rule associated with trackingId and extract those that are not included in ruleNames.
+func extractOrphanedRules(ctx context.Context, sess *session.Session, base *BaseConfig, ruleNames []string) ([]*Rule, error) {
+	trackedRuleNames, err := listTrackedRules(ctx, sess, base.Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	var orphanedRuleNames []string
+	for _, trackedRuleName := range trackedRuleNames {
+		if !slices.Contains(ruleNames, trackedRuleName) {
+			orphanedRuleNames = append(orphanedRuleNames, trackedRuleName)
+		}
+	}
+
+	var orphanedRules []*Rule
+	for _, orphanedRuleName := range orphanedRuleNames {
+		orphanedRule, err := NewRuleFromRemote(ctx, sess, base, orphanedRuleName)
+		if err != nil {
+			return nil, err
+		}
+		orphanedRules = append(orphanedRules, orphanedRule)
+	}
+
+	return orphanedRules, nil
+}
+
+// Using the SearchResources API of the AWS Resource Groups service, extract the Rule with
+// the following tags from `AWS::Events::Rule`.
+// - Key: 'ecschedule:tracking-id'
+// - Value: tracking_id
+func listTrackedRules(ctx context.Context, sess *session.Session, trackingId string) ([]string, error) {
+	svc := resourcegroups.New(sess)
+	q := Query{
+		ResourceTypeFIlters: []string{"AWS::Events::Rule"},
+		TagFilters: []TagFilter{
+			{
+				Key: "ecschedule:tracking-id",
+				Values: []string{trackingId},
+			},
+		},
+	}
+	queryBytes, err := json.Marshal(q)
+	if err != nil {
+		return []string{}, err
+	}
+
+	input := &resourcegroups.SearchResourcesInput{
+		ResourceQuery: &resourcegroups.ResourceQuery{
+			Type: aws.String(resourcegroups.QueryTypeTagFilters10),
+			Query: aws.String(string(queryBytes)),
+		},
+	}
+	result, err := svc.SearchResourcesWithContext(ctx, input)
+	if err != nil {
+		return []string{}, err
+	}
+	if result.ResourceIdentifiers == nil {
+		return []string{}, nil
+	}
+
+	var ruleNames []string
+	for _, identifier := range result.ResourceIdentifiers {
+		arn := *identifier.ResourceArn
+		arnElements := strings.Split(arn, "/")
+		ruleName := arnElements[len(arnElements) - 1]
+		ruleNames = append(ruleNames, ruleName)
+	}
+
+	return ruleNames, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
+	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.5.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb h1:mIKbk8weKhSeLH2GmUTrvx8CjkyJmnU1wFmg59CUjFA=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/rule.go
+++ b/rule.go
@@ -136,7 +136,7 @@ func NewRuleFromRemote(ctx context.Context, sess *session.Session, bc *BaseConfi
 	}
 
 	var (
-		rg            = &ruleGetter{
+		rg = &ruleGetter{
 			svc:              cw,
 			ruleArnPrefix:    fmt.Sprintf("arn:aws:events:%s:%s:rule/", bc.Region, bc.AccountID),
 			clusterArn:       fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", bc.Region, bc.AccountID, bc.Cluster),

--- a/rule.go
+++ b/rule.go
@@ -171,10 +171,6 @@ func NewRuleFromRemote(ctx context.Context, sess *session.Session, bc *BaseConfi
 	return newRule, nil
 }
 
-func (r *Rule) trackingID() string {
-	return r.Cluster
-}
-
 func (r *Rule) roleARN() string {
 	if strings.HasPrefix(r.Role, "arn:") {
 		return r.Role
@@ -294,7 +290,7 @@ func (r *Rule) TagResourceInput() *cloudwatchevents.TagResourceInput {
 		Tags: []*cloudwatchevents.Tag{
 			{
 				Key:   aws.String("ecschedule:tracking-id"),
-				Value: aws.String(r.trackingID()),
+				Value: aws.String(r.Cluster),
 			},
 		},
 	}


### PR DESCRIPTION
## Motivation

- I aim to solve the problem where orphaned Rules remain on the AWS side when Rule names listed in the config are changed or Rules are deleted.

## Approach

- When deploying a Rule (a.k.a. Scheduled Task), a Tag is added to track the deployment unit.
    - The Tag name is `ecschedule:tracking-id`, and its value is the Cluster name set in the config.yaml.
    - This tag is given with or without the `-prune` option.
- Adding a `-prune` option to `ecschedule apply`.
    - The `-prune` option requires the Rule to have been tagged with `ecschedule:tracking-id` in advance in order to work correctly.
        - However, it is not a fatal problem, since the Rule will not be deleted if the tag is not given.
    - When this option is specified, Orphaned Rules will be deleted from AWS after the regular deployment process.
    - The criteria for determining "Orphaned Rules" are as follows:
        - Extract Rules on AWS with a `ecschedule:tracking-id` Tag value that matches the deployment target Cluster name.
        - From the above, determine Rules not defined in the config.yaml as "Orphaned Rules".
- To prevent accidental deletion of Rules, the default behavior is set to "do not delete". The deletion occurs only when the `-prune` option is specified.
- Using the `-prune` option requires the `-all` option to be specified as well.

## Execution example

(dry-run)

<img src=https://github.com/Songmu/ecschedule/assets/19329/10c19d66-9461-4ce7-be86-6b33e45504a5 width=500>


## Points to Note

- My experience with Go language projects is limited, so I might have implemented something that deviates from common practices.
- The documentation hasn't been updated yet.
    - If this Pull Request is accepted, modifications to the documentation (README) will also be added.


