### PR TITLE
fix: `-conf` omitted caused panic by referencing a nil pointer

### DIFF
--- a/cmd_apply.go
+++ b/cmd_apply.go
@@ -44,6 +44,9 @@ var cmdApply = &runnerImpl{
 				return err
 			}
 		}
+		if c == nil {
+			return errors.New("-conf option required")
+		}
 
 		var ruleNames []string
 		if !*all {

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -44,6 +44,9 @@ var cmdDiff = &runnerImpl{
 				return err
 			}
 		}
+		if c == nil {
+			return errors.New("-conf option required")
+		}
 
 		var ruleNames []string
 		if !*all {

--- a/cmd_run.go
+++ b/cmd_run.go
@@ -41,6 +41,9 @@ var cmdRun = &runnerImpl{
 				return err
 			}
 		}
+		if c == nil {
+			return errors.New("-conf option required")
+		}
 		ru := c.GetRuleByName(*rule)
 		if ru == nil {
 			return fmt.Errorf("no rules found for %s", *rule)


### PR DESCRIPTION
## Problem Encountered

For the subcommands `apply`, `diff`, and `run`, specifying the `config.yaml` file via the `-conf` option seems to be required.

However, there is no required check for this in the program. Consequently, it attempts to reference a non-existent config. Being `nil`, this situation leads to a panic.

```console
$ ecschedule diff -all
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x103212560]

goroutine 1 [running]:
github.com/Songmu/ecschedule.glob..func2({0x1038b0cc0, 0x14000391860}, {0x1400003a1d0, 0x1, 0x1}, {0x3?, 0x103679e20?}, {0x1038a4660?, 0x1400000e020})
        github.com/Songmu/ecschedule/cmd_diff.go:52 +0x260
github.com/Songmu/ecschedule.(*runnerImpl).Run(0x1036ea140?, {0x1038b0cc0?, 0x14000391860?}, {0x1400003a1d0?, 0x10363b3a0?, 0x140003c84c0?}, {0x1038a4660?, 0x1400000e018?}, {0x1038a4660?, 0x1400000e020?})
        github.com/Songmu/ecschedule/commands.go:72 +0x64
github.com/Songmu/ecschedule.Run({0x1038b0c50, 0x140000420a0}, {0x1400003a1c0, 0x2, 0x2}, {0x1038a4660, 0x1400000e018}, {0x1038a4660?, 0x1400000e020})
        github.com/Songmu/ecschedule/ecsched.go:75 +0x63c
main.main()
        github.com/Songmu/ecschedule/cmd/ecschedule/main.go:14 +0xa0

```

## Proposed Changes

I've added a required check for the `-conf` option to these subcommands. If the `-conf` option isn't provided, it will now display the following error message:

```console
 -conf option required
```