### PR TITLE
Align remote and conf override members

### DIFF
--- a/rule_getter.go
+++ b/rule_getter.go
@@ -82,9 +82,12 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cloudwatchevents.Rule) (*R
 					env[*kv.Name] = *kv.Value
 				}
 				contOverrides = append(contOverrides, &ContainerOverride{
-					Name:        *co.Name,
-					Command:     cmd,
-					Environment: env,
+					Name:              *co.Name,
+					Command:           cmd,
+					Environment:       env,
+					Cpu:               co.Cpu,
+					Memory:            co.Memory,
+					MemoryReservation: co.MemoryReservation,
 				})
 			}
 			target.ContainerOverrides = contOverrides


### PR DESCRIPTION
I'm sorry 🙇 
This is an implementation omission in this PR from me.

- https://github.com/Songmu/ecschedule/pull/62

Without this, resource diffs will be detected every time.