### PR TITLE
Care remote PropagateTags default value

### DIFF
--- a/rule_getter.go
+++ b/rule_getter.go
@@ -57,6 +57,9 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 		target.LaunchType = string(ecsParams.LaunchType)
 		target.PlatformVersion = aws.ToString(ecsParams.PlatformVersion)
 		target.PropagateTags = aws.String(string(t.EcsParameters.PropagateTags))
+		if aws.ToString(target.PropagateTags) == "" {
+			target.PropagateTags = nil
+		}
 		if nc := ecsParams.NetworkConfiguration; nc != nil {
 			target.NetworkConfiguration = &NetworkConfiguration{
 				AwsVpcConfiguration: &AwsVpcConfiguration{


### PR DESCRIPTION
Hi,

Observed an issue where undefined propagateTags in both remote and local leads to consistent false diffs. This change aims to prevent these unintended detections, improving accuracy in configuration comparisons.

![image](https://github.com/Songmu/ecschedule/assets/329120/f820f989-4cd2-4fed-8fef-773934f6c5ed)


