### PR TITLE
Add config of `trackingId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The ecschedule manages ECS Schedule tasks using a configuration file (YAML, JSON
 region: us-east-1
 cluster: clusterName
 rules:
+trackingId: trackingId1
 - name: taskName1
   description: task 1
   scheduleExpression: cron(30 15 ? * * *)
@@ -118,6 +119,9 @@ To see which rules would be deleted without actually removing them, combine with
 ```console
 % ecschedule -conf ecschedule.yaml apply -all -prune -dry-run
 ```
+
+A `trackingId` is an optional key in a configuration file. If the `trackingId` is not explicitly specified, the cluster name will be used as the `trackingId` by default.
+When you explicitly specify the `trackingId`, it enables you to detect rule deletions for each file when executing multiple configuration files at different times.
 
 ## Functions
 

--- a/config.go
+++ b/config.go
@@ -23,9 +23,10 @@ const (
 
 // BaseConfig baseconfig
 type BaseConfig struct {
-	Region    string `yaml:"region" json:"region"`
-	Cluster   string `yaml:"cluster" json:"cluster"`
-	AccountID string `yaml:"-" json:"-"`
+	Region     string `yaml:"region" json:"region"`
+	Cluster    string `yaml:"cluster" json:"cluster"`
+	AccountID  string `yaml:"-" json:"-"`
+	TrackingID string `yaml:"trakingId,omitempty" json:"trakingId,omitempty"`
 }
 
 // Config config
@@ -74,6 +75,9 @@ func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath str
 		return nil, err
 	}
 	c.AccountID = accountID
+	if c.TrackingID == "" {
+		c.TrackingID = c.Cluster
+	}
 	if err := c.setupPlugins(ctx); err != nil {
 		return nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ type BaseConfig struct {
 	Region     string `yaml:"region" json:"region"`
 	Cluster    string `yaml:"cluster" json:"cluster"`
 	AccountID  string `yaml:"-" json:"-"`
-	TrackingID string `yaml:"trakingId,omitempty" json:"trakingId,omitempty"`
+	TrackingID string `yaml:"trackingId,omitempty" json:"trackingId,omitempty"`
 }
 
 // Config config

--- a/config_test.go
+++ b/config_test.go
@@ -15,9 +15,10 @@ func TestLoadConfig(t *testing.T) {
 	expect := &Config{
 		Role: "ecsEventsRole",
 		BaseConfig: &BaseConfig{
-			Region:    "us-east-1",
-			Cluster:   "api",
-			AccountID: "334",
+			Region:     "us-east-1",
+			Cluster:    "api",
+			AccountID:  "334",
+			TrackingID: "api",
 		},
 		Rules: []*Rule{
 			{
@@ -58,9 +59,10 @@ func TestLoadConfig(t *testing.T) {
 					Role:          "ecsEventsRole",
 				},
 				BaseConfig: &BaseConfig{
-					Region:    "us-east-1",
-					Cluster:   "api",
-					AccountID: "334",
+					Region:     "us-east-1",
+					Cluster:    "api",
+					AccountID:  "334",
+					TrackingID: "api",
 				},
 			},
 		},

--- a/event_bridge.go
+++ b/event_bridge.go
@@ -23,7 +23,7 @@ type TagFilter struct {
 
 // Extract the Rule associated with trackingId and extract those that are not included in ruleNames.
 func extractOrphanedRules(ctx context.Context, awsConf aws.Config, base *BaseConfig, ruleNames []string) ([]*Rule, error) {
-	trackedRuleNames, err := listTrackedRules(ctx, awsConf, base.Cluster)
+	trackedRuleNames, err := listTrackedRules(ctx, awsConf, base.TrackingID)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func extractOrphanedRules(ctx context.Context, awsConf aws.Config, base *BaseCon
 // Using the SearchResources API of the AWS Resource Groups service, extract the Rule with
 // the following tags from `AWS::Events::Rule`.
 // - Key: 'ecschedule:tracking-id'
-// - Value: tracking_id
+// - Value: base.TrackingId
 func listTrackedRules(ctx context.Context, awsConf aws.Config, trackingId string) ([]string, error) {
 	svc := resourcegroups.NewFromConfig(awsConf, func(o *resourcegroups.Options) {
 		o.Region = awsConf.Region

--- a/rule.go
+++ b/rule.go
@@ -265,6 +265,9 @@ func (r *Rule) mergeBaseConfig(bc *BaseConfig, role string) {
 	if r.AccountID == "" {
 		r.AccountID = bc.AccountID
 	}
+	if r.TrackingID == "" {
+		r.TrackingID = bc.TrackingID
+	}
 }
 
 // PutRuleInput puts rule input
@@ -293,7 +296,7 @@ func (r *Rule) TagResourceInput() *cloudwatchevents.TagResourceInput {
 		Tags: []cweTypes.Tag{
 			{
 				Key:   aws.String("ecschedule:tracking-id"),
-				Value: aws.String(r.Cluster),
+				Value: aws.String(r.TrackingID),
 			},
 		},
 	}


### PR DESCRIPTION
I have tried specifying a `trackingId` in YAML.

> We have a problem when trying to use the -prune option in our project.
> Our project has multiple YAML files for the same environment, and when we execute a command with the -prune option, settings from the last apply YAML file overwrite the others.

Related Issue: https://github.com/Songmu/ecschedule/issues/92

A `trackingId` is explicitly specified in a configuration file.
``` event-rules.yaml
region: ap-northeast-1
cluster: staging
role: ecsTaskExecutionRole
trackingId: test-tag
rules:
...
```
The EventBridge console
![image](https://github.com/Songmu/ecschedule/assets/41310325/ba577182-fac4-402e-854d-a2acb7097f1f)

When a `trackingId` is not specified, the default value is set to the cluster name (ex.`staging`).
The EventBridge console
![image](https://github.com/Songmu/ecschedule/assets/41310325/18709522-b1e5-4760-9c6e-06753e5093d2)


this closes https://github.com/Songmu/ecschedule/issues/92