### PR TITLE
Support CapacityProviderStrategy

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -32,6 +32,13 @@ func TestLoadConfig(t *testing.T) {
 					Group:           "xxx",
 					PlatformVersion: "1.4.0",
 					LaunchType:      "FARGATE",
+					CapacityProviderStrategy: []*CapacityProviderStrategyItem{
+						{
+							CapacityProvider: "FARGATE",
+							Weight:           1,
+							Base:             1,
+						},
+					},
 					NetworkConfiguration: &NetworkConfiguration{
 						AwsVpcConfiguration: &AwsVpcConfiguration{
 							Subnets:        []string{"subnet-01234567", "subnet-12345678"},

--- a/rule.go
+++ b/rule.go
@@ -31,17 +31,25 @@ type Rule struct {
 
 // Target cluster
 type Target struct {
-	TargetID             string                `yaml:"targetId,omitempty" json:"targetId,omitempty"`
-	TaskDefinition       string                `yaml:"taskDefinition" json:"taskDefinition"`
-	TaskCount            int32                 `yaml:"taskCount,omitempty" json:"taskCount,omitempty"`
-	ContainerOverrides   []*ContainerOverride  `yaml:"containerOverrides,omitempty" json:"containerOverrides,omitempty"`
-	Role                 string                `yaml:"role,omitempty" json:"role,omitempty"`
-	Group                string                `yaml:"group,omitempty" json:"group,omitempty"`
-	LaunchType           string                `yaml:"launch_type,omitempty" json:"launch_type,omitempty"`
-	PlatformVersion      string                `yaml:"platform_version,omitempty" json:"platform_version,omitempty"`
-	NetworkConfiguration *NetworkConfiguration `yaml:"network_configuration,omitempty" json:"network_configuration,omitempty"`
-	DeadLetterConfig     *DeadLetterConfig     `yaml:"dead_letter_config,omitempty" json:"dead_letter_config,omitempty"`
-	PropagateTags        *string               `yaml:"propagateTags,omitempty" json:"propagateTags,omitempty"`
+	TargetID                 string                          `yaml:"targetId,omitempty" json:"targetId,omitempty"`
+	TaskDefinition           string                          `yaml:"taskDefinition" json:"taskDefinition"`
+	TaskCount                int32                           `yaml:"taskCount,omitempty" json:"taskCount,omitempty"`
+	ContainerOverrides       []*ContainerOverride            `yaml:"containerOverrides,omitempty" json:"containerOverrides,omitempty"`
+	Role                     string                          `yaml:"role,omitempty" json:"role,omitempty"`
+	Group                    string                          `yaml:"group,omitempty" json:"group,omitempty"`
+	CapacityProviderStrategy []*CapacityProviderStrategyItem `yaml:"capacityProviderStrategy,omitempty" json:"capacityProviderStrategy,omitempty"`
+	LaunchType               string                          `yaml:"launch_type,omitempty" json:"launch_type,omitempty"`
+	PlatformVersion          string                          `yaml:"platform_version,omitempty" json:"platform_version,omitempty"`
+	NetworkConfiguration     *NetworkConfiguration           `yaml:"network_configuration,omitempty" json:"network_configuration,omitempty"`
+	DeadLetterConfig         *DeadLetterConfig               `yaml:"dead_letter_config,omitempty" json:"dead_letter_config,omitempty"`
+	PropagateTags            *string                         `yaml:"propagateTags,omitempty" json:"propagateTags,omitempty"`
+}
+
+// CapacityProviderStrategyItem represents ECS capacity provider strategy item
+type CapacityProviderStrategyItem struct {
+	CapacityProvider string `yaml:"capacityProvider" json:"capacityProvider"`
+	Base             int32  `yaml:"base" json:"base"`
+	Weight           int32  `yaml:"weight" json:"weight"`
 }
 
 // ContainerOverride overrides container
@@ -222,6 +230,17 @@ func (r *Rule) ecsParameters() *cweTypes.EcsParameters {
 	if ta.LaunchType != "" {
 		p.LaunchType = cweTypes.LaunchType(ta.LaunchType)
 	}
+
+	var capacityProviderStrategy []cweTypes.CapacityProviderStrategyItem
+	for _, cps := range ta.CapacityProviderStrategy {
+		capacityProviderStrategy = append(capacityProviderStrategy, cweTypes.CapacityProviderStrategyItem{
+			CapacityProvider: aws.String(cps.CapacityProvider),
+			Base:             cps.Base,
+			Weight:           cps.Weight,
+		})
+	}
+	p.CapacityProviderStrategy = capacityProviderStrategy
+
 	if ta.PlatformVersion != "" {
 		p.PlatformVersion = aws.String(ta.PlatformVersion)
 	}

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -55,6 +55,18 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 
 		target.Group = aws.ToString(ecsParams.Group)
 		target.LaunchType = string(ecsParams.LaunchType)
+
+		var capacityProviderStrategy []*CapacityProviderStrategyItem
+		for _, cps := range ecsParams.CapacityProviderStrategy {
+			capacityProviderStrategy = append(capacityProviderStrategy, &CapacityProviderStrategyItem{
+				Base:             cps.Base,
+				Weight:           cps.Weight,
+				CapacityProvider: aws.ToString(cps.CapacityProvider),
+			})
+		}
+
+		target.CapacityProviderStrategy = capacityProviderStrategy
+
 		target.PlatformVersion = aws.ToString(ecsParams.PlatformVersion)
 		target.PropagateTags = aws.String(string(t.EcsParameters.PropagateTags))
 		if aws.ToString(target.PropagateTags) == "" {

--- a/testdata/sample.json
+++ b/testdata/sample.json
@@ -11,6 +11,13 @@
       "group": "xxx",
       "platform_version": "1.4.0",
       "launch_type": "FARGATE",
+      "capacityProviderStrategy": [
+        {
+          "capacityProvider": "FARGATE",
+          "base": 1,
+          "weight": 1
+        }
+      ],
       "network_configuration": {
         "aws_vpc_configuration": {
           "subnets": [

--- a/testdata/sample.jsonnet
+++ b/testdata/sample.jsonnet
@@ -13,6 +13,13 @@ local envs = import 'envs.libsonnet';
       "group": "xxx",
       "platform_version": "1.4.0",
       "launch_type": "FARGATE",
+      "capacityProviderStrategy": [
+        {
+          "capacityProvider": "FARGATE",
+          "base": 1,
+          "weight": 1
+        }
+      ],
       "network_configuration": envs.network_configuration,
       "containerOverrides": [
         {

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -9,6 +9,10 @@ rules:
   group: xxx
   platform_version: 1.4.0
   launch_type: FARGATE
+  capacityProviderStrategy:
+  - capacityProvider: "FARGATE"
+    base: 1
+    weight: 1
   network_configuration:
     aws_vpc_configuration:
       subnets:


### PR DESCRIPTION
This PR resolves https://github.com/Songmu/ecschedule/issues/66.

This PR add [CapacityProviderStrategy](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_EcsParameters.html#eventbridge-Type-EcsParameters-CapacityProviderStrategy) option to each target. 

CapacityProvider allows to launch ECS Task with fargate spot. CapacityProvider can trigger ECS Cluster Auto Scaling to allocate required an ECS instance to run the ECS Task.

## Ref: 

For more details about Capacity Providers, see the following articles.

* [Capacity Providerとは？ECSの次世代スケーリング戦略を解説する #reinvent #cmregrowth | DevelopersIO](https://dev.classmethod.jp/articles/regrwoth-capacity-provider/)
* [ECS on EC2におけるスケーリングの辛みを「Capacity Provider」で解決する | DevelopersIO](https://dev.classmethod.jp/articles/ecs_on_ec2_capacity_provider/)
* [Amazon ECS standalone tasks - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/standalone-tasks.html)