### PR TITLE
Multiple tfstate support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,31 @@ This function is useful to build a resource address with environment variables.
 {{ tfstatef `aws_subnet.ecs['%s'].id` (must_env `SERVICE`) }}
 ```
 
+#### Multiple tfstate support
+
+You can specify multiple tfstate files. Specify the `func_prefix` option to avoid conflicts between functions.
+
+```yaml
+plugins:
+- name: tfstate
+  func_prefix: first_
+  config:
+    path: testdata/first_terraform.tfstate    # path to tfstate file
+- name: tfstate
+  func_prefix: second_
+  config:
+    path: testdata/second_terraform.tfstate    # path to tfstate file
+```
+
+In this case, the function must be called by the `plugin` function.
+
+The `plugin` function takes the prefixed function name as the first argument and the function arguments as the second or later arguments.
+
+```
+{{ plugin `first_tfstate` `aws_subnet.private-a.id` }}
+{{ plugin `second_tfstate` `aws_subnet.private-a.id` }}
+```
+
 ### ssm
 
 ssm plugin introduces a template function `ssm`.

--- a/config.go
+++ b/config.go
@@ -58,28 +58,6 @@ func (c *Config) setupPlugins(ctx context.Context) error {
 	return nil
 }
 
-func (c *Config) buildPluginFunc() template.FuncMap {
-	funcMap := template.FuncMap{}
-	for _, f := range c.templateFuncs {
-		for k, v := range f {
-			funcMap[k] = v
-		}
-	}
-	return template.FuncMap{
-		"plugin": func(name string, args ...string) string {
-			fn := funcMap[name]
-			switch fn := fn.(type) {
-			case func(string, ...string) string:
-				return fn(name, args...)
-			case func(string) string:
-				return fn(name)
-			default:
-				panic(fmt.Sprintf("plugin %s is not available", name))
-			}
-		},
-	}
-}
-
 // LoadConfig loads config
 func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath string) (*Config, error) {
 	c := Config{}
@@ -104,10 +82,7 @@ func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath str
 	for _, f := range c.templateFuncs {
 		loader.Funcs(f)
 	}
-	loader.Funcs(c.buildPluginFunc())
 
-	// recover plugin variable (must at first)
-	bs = pluginRecover(bs)
 	// recover tfstate variable
 	bs = tfstateRecover(bs)
 	// recover ssm variable

--- a/config.go
+++ b/config.go
@@ -82,7 +82,6 @@ func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath str
 	for _, f := range c.templateFuncs {
 		loader.Funcs(f)
 	}
-
 	// recover tfstate variable
 	bs = tfstateRecover(bs)
 	// recover ssm variable

--- a/config.go
+++ b/config.go
@@ -58,6 +58,28 @@ func (c *Config) setupPlugins(ctx context.Context) error {
 	return nil
 }
 
+func (c *Config) buildPluginFunc() template.FuncMap {
+	funcMap := template.FuncMap{}
+	for _, f := range c.templateFuncs {
+		for k, v := range f {
+			funcMap[k] = v
+		}
+	}
+	return template.FuncMap{
+		"plugin": func(name string, args ...string) string {
+			fn := funcMap[name]
+			switch fn := fn.(type) {
+			case func(string, ...string) string:
+				return fn(name, args...)
+			case func(string) string:
+				return fn(name)
+			default:
+				panic(fmt.Sprintf("plugin %s is not available", name))
+			}
+		},
+	}
+}
+
 // LoadConfig loads config
 func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath string) (*Config, error) {
 	c := Config{}
@@ -82,6 +104,10 @@ func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath str
 	for _, f := range c.templateFuncs {
 		loader.Funcs(f)
 	}
+	loader.Funcs(c.buildPluginFunc())
+
+	// recover plugin variable (must at first)
+	bs = pluginRecover(bs)
 	// recover tfstate variable
 	bs = tfstateRecover(bs)
 	// recover ssm variable

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/Songmu/ecschedule
 go 1.22.5
 
 require (
+	github.com/fujiwara/ssm-lookup v0.1.1
 	github.com/fujiwara/tfstate-lookup v1.3.2
 	github.com/goccy/go-yaml v1.11.3
 	github.com/google/go-jsonnet v0.20.0
-	github.com/kayac/ecspresso v1.99.3
 	github.com/kayac/go-config v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ cloud.google.com/go/longrunning v0.5.8 h1:QThI5BFSlYlS7K0wnABCdmKsXbG/htLc3nTPzr
 cloud.google.com/go/longrunning v0.5.8/go.mod h1:oJDErR/mm5h44gzsfjQlxd6jyjFvuBPOxR1TLy2+cQk=
 cloud.google.com/go/storage v1.43.0 h1:CcxnSohZwizt4LCzQHWvBf1/kvtHUn7gk9QERXPyXFs=
 cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
-github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0 h1:1nGuui+4POelzDwI7RG56yfQJHCnKvwfMoU7VsEp+Zg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0/go.mod h1:99EvauvlcJ1U06amZiksfYz/3aFGyIhWGHVyiZXtBAI=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=
@@ -111,6 +110,8 @@ github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fujiwara/ssm-lookup v0.1.1 h1:Cwx7Y6A0HbIKyAzS60DYcf/TZ5KZHY/vTlCtUoythfQ=
+github.com/fujiwara/ssm-lookup v0.1.1/go.mod h1:ssVwS1FrHAKouOMEmYC6j07XRKqBGdABRmv6gBKewVg=
 github.com/fujiwara/tfstate-lookup v1.3.2 h1:jfPPRecZ9yzPI0epCnK5UCxY3CQAAF0Iq4L3osJ3d58=
 github.com/fujiwara/tfstate-lookup v1.3.2/go.mod h1:qYLO+8Ane5hF54BdvLQTbXiHWviq3uGCuW6Lz3fcWCM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -198,8 +199,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/kayac/ecspresso v1.99.3 h1:vxRLEjRmrkC71C6yP6DgmkJbw4hOvLpOJ+ETX6/1Fx0=
-github.com/kayac/ecspresso v1.99.3/go.mod h1:nmEy38MkGe3oEZwpT/t9bDhqPjkSOJMk9RTgXGW1r7o=
 github.com/kayac/go-config v0.7.0 h1:BeONaFFq/ILFiEzkCMpKarsjcc3YBgJ7QKg39hXU+nk=
 github.com/kayac/go-config v0.7.0/go.mod h1:Nfkw4LZOh/7HGepftBvD2lKEpPyl1Vp89yA7gDJS5r0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/plugin.go
+++ b/plugin.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/fujiwara/tfstate-lookup/tfstate"
-        "github.com/kayac/ecspresso/ssm"
+	"github.com/kayac/ecspresso/ssm"
 )
 
 // Plugin the plugin
@@ -21,8 +21,8 @@ func (p Plugin) setup(ctx context.Context, c *Config) error {
 	switch strings.ToLower(p.Name) {
 	case "tfstate":
 		return setupPluginTFState(ctx, p, c)
-        case "ssm":
-                return setupPluginSSM(ctx, c)
+	case "ssm":
+		return setupPluginSSM(ctx, c)
 	default:
 		return fmt.Errorf("plugin %s is not available", p.Name)
 	}
@@ -57,10 +57,10 @@ func setupPluginTFState(ctx context.Context, p Plugin, c *Config) error {
 }
 
 func setupPluginSSM(ctx context.Context, c *Config) error {
-        funcs, err := ssm.FuncMap(ctx, getApp(ctx).AwsConf)
-        if err != nil {
-                return err
-        }
-        c.templateFuncs = append(c.templateFuncs, funcs)
-        return nil
+	funcs, err := ssm.FuncMap(ctx, getApp(ctx).AwsConf)
+	if err != nil {
+		return err
+	}
+	c.templateFuncs = append(c.templateFuncs, funcs)
+	return nil
 }

--- a/plugin.go
+++ b/plugin.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"github.com/fujiwara/ssm-lookup/ssm"
 	"github.com/fujiwara/tfstate-lookup/tfstate"
-	"github.com/kayac/ecspresso/ssm"
 )
 
 // Plugin the plugin
 type Plugin struct {
-	Name   string                 `yaml:"name"`
-	Config map[string]interface{} `yaml:"config"`
+	Name       string                 `yaml:"name"`
+	Config     map[string]interface{} `yaml:"config"`
+	FuncPrefix string                 `yaml:"func_prefix,omitempty"`
 }
 
 func (p Plugin) setup(ctx context.Context, c *Config) error {
@@ -22,7 +24,7 @@ func (p Plugin) setup(ctx context.Context, c *Config) error {
 	case "tfstate":
 		return setupPluginTFState(ctx, p, c)
 	case "ssm":
-		return setupPluginSSM(ctx, c)
+		return setupPluginSSM(ctx, p, c)
 	default:
 		return fmt.Errorf("plugin %s is not available", p.Name)
 	}
@@ -48,7 +50,7 @@ func setupPluginTFState(ctx context.Context, p Plugin, c *Config) error {
 	} else {
 		return errors.New("tfstate plugin requires path or url for tfstate location")
 	}
-	funcs, err := tfstate.FuncMapWithName(ctx, "tfstate", loc)
+	funcs, err := tfstate.FuncMapWithName(ctx, p.FuncPrefix+"tfstate", loc)
 	if err != nil {
 		return err
 	}
@@ -56,11 +58,10 @@ func setupPluginTFState(ctx context.Context, p Plugin, c *Config) error {
 	return nil
 }
 
-func setupPluginSSM(ctx context.Context, c *Config) error {
-	funcs, err := ssm.FuncMap(ctx, getApp(ctx).AwsConf)
-	if err != nil {
-		return err
-	}
+func setupPluginSSM(ctx context.Context, p Plugin, c *Config) error {
+	cache := &sync.Map{}
+	s := ssm.New(getApp(ctx).AwsConf, cache)
+	funcs := s.FuncMapWithName(ctx, p.FuncPrefix+"ssm")
 	c.templateFuncs = append(c.templateFuncs, funcs)
 	return nil
 }

--- a/template.go
+++ b/template.go
@@ -14,9 +14,10 @@ import (
 )
 
 var envRepTpl *template.Template
-var tfstateRepRegex = regexp.MustCompile("ecschedule::tfstate::<`(.*)`>")
-var tfstatefRepRegex = regexp.MustCompile("ecschedule::tfstatef::<`(.*)`>")
-var ssmRepRegex = regexp.MustCompile("ecschedule::ssm::<(.*)>")
+var tfstateRepRegex = regexp.MustCompile("ecschedule::(.*?tfstate)::<`(.*)`>")
+var tfstatefRepRegex = regexp.MustCompile("ecschedule::(.*?tfstatef)::<`(.*)`>")
+var ssmRepRegex = regexp.MustCompile("ecschedule::(.*?ssm)::<(.*)>")
+var pluginRepRegex = regexp.MustCompile("ecschedule::plugin::<(.*)>")
 
 func init() {
 	envRepTpl = template.New("conf").Funcs(template.FuncMap{
@@ -50,6 +51,9 @@ func init() {
 				return fmt.Sprintf("ecschedule::ssm::<`%s`>", key)
 			}
 		},
+		"plugin": func(name string, args ...string) string {
+			return fmt.Sprintf("ecschedule::%s::<`%s`>", name, strings.Join(args, "` `"))
+		},
 	})
 }
 
@@ -66,11 +70,15 @@ func envReplacer(data []byte) ([]byte, error) {
 }
 
 func tfstateRecover(data []byte) []byte {
-	s := tfstateRepRegex.ReplaceAllString(string(data), "{{ tfstate `$1` }}")
-	s = tfstatefRepRegex.ReplaceAllString(s, "{{ tfstatef `$1` }}")
+	s := tfstateRepRegex.ReplaceAllString(string(data), "{{ $1 `$2` }}")
+	s = tfstatefRepRegex.ReplaceAllString(s, "{{ $1 `$2` }}")
 	return []byte(s)
 }
 
 func ssmRecover(data []byte) []byte {
 	return []byte(ssmRepRegex.ReplaceAllString(string(data), "{{ ssm $1 }}"))
+}
+
+func pluginRecover(data []byte) []byte {
+	return []byte(pluginRepRegex.ReplaceAllString(string(data), "{{ plugin $1 }}"))
 }

--- a/template.go
+++ b/template.go
@@ -17,7 +17,6 @@ var envRepTpl *template.Template
 var tfstateRepRegex = regexp.MustCompile("ecschedule::(.*?tfstate)::<`(.*)`>")
 var tfstatefRepRegex = regexp.MustCompile("ecschedule::(.*?tfstatef)::<`(.*)`>")
 var ssmRepRegex = regexp.MustCompile("ecschedule::(.*?ssm)::<(.*)>")
-var pluginRepRegex = regexp.MustCompile("ecschedule::plugin::<(.*)>")
 
 func init() {
 	envRepTpl = template.New("conf").Funcs(template.FuncMap{
@@ -76,9 +75,5 @@ func tfstateRecover(data []byte) []byte {
 }
 
 func ssmRecover(data []byte) []byte {
-	return []byte(ssmRepRegex.ReplaceAllString(string(data), "{{ ssm $1 }}"))
-}
-
-func pluginRecover(data []byte) []byte {
-	return []byte(pluginRepRegex.ReplaceAllString(string(data), "{{ plugin $1 }}"))
+	return []byte(ssmRepRegex.ReplaceAllString(string(data), "{{ $1 $2 }}"))
 }

--- a/testdata/sample5.yaml
+++ b/testdata/sample5.yaml
@@ -1,0 +1,37 @@
+region: us-east-1
+cluster: api
+role: ecsEventsRole
+rules:
+- name: hoge-task-name
+  description: hoge description
+  scheduleExpression: cron(0 0 * * ? *)
+  taskDefinition: task1
+  group: xxx
+  platform_version: 1.4.0
+  launch_type: FARGATE
+  network_configuration:
+    aws_vpc_configuration:
+      subnets:
+      - {{ plugin `first_tfstate` `aws_subnet.private-a.id` }}
+      - {{ plugin `second_tfstate` `aws_subnet.private-c.id` }}
+      security_groups:
+      - {{ plugin `first_tfstatef` `data.aws_security_group.default['%s'].id` `first` }}
+      - {{ plugin `second_tfstatef` `data.aws_security_group.default['%s'].id` `second` }}
+      assign_public_ip: ENABLED
+  containerOverrides:
+  - name: container1
+    command: ["subcmd", "argument"]
+    environment:
+      HOGE_ENV: {{ env "DUMMY_HOGE_ENV" "HOGEGE" }}
+  dead_letter_config:
+    sqs: queue1
+  propagateTags: TASK_DEFINITION
+plugins:
+- name: tfstate
+  config:
+    path: testdata/terraform.tfstate
+  func_prefix: first_
+- name: tfstate
+  config:
+    path: testdata/terraform.tfstate
+  func_prefix: second_


### PR DESCRIPTION
refs #70.

This pull request introduces support for multiple tfstate files and enhances the plugin system to handle prefixed functions.

- Add `func_prefix` to the plugin settings. This prefix is applied to the generated plugin function name.
- Add the `plugin` template function. This function replaces calling any template function to internal expressions.
- Switch to fujiwara/ssm-lookup from kayac/ecspresso/ssm.
  - ecspresso v2 uses fujiwara/ssm-lookup.

---

#### Multiple tfstate support

You can specify multiple tfstate files. Specify the `func_prefix` option to avoid conflicts between functions.

```yaml
plugins:
- name: tfstate
  func_prefix: first_
  config:
    path: testdata/first_terraform.tfstate    # path to tfstate file
- name: tfstate
  func_prefix: second_
  config:
    path: testdata/second_terraform.tfstate    # path to tfstate file
```

In this case, the function must be called by the `plugin` function.

The `plugin` function takes the prefixed function name as the first argument and the function arguments as the second or later arguments.

```
{{ plugin `first_tfstate` `aws_subnet.private-a.id` }}
{{ plugin `second_tfstate` `aws_subnet.private-a.id` }}
```


