### PR TITLE
add retry option for better reliability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
   - run: |
       TEMP_PATH="$(mktemp -d)"
-      curl -sfL https://raw.githubusercontent.com/Songmu/ecschedule/main/install.sh | sh -s -- -b "${TEMP_PATH}" "${{ inputs.version }}" 2>&1
+      curl -sfL --retry 3 https://raw.githubusercontent.com/Songmu/ecschedule/main/install.sh | sh -s -- -b "${TEMP_PATH}" "${{ inputs.version }}" 2>&1
       sudo mv ${TEMP_PATH}/ecschedule /usr/local/bin/ecschedule
       rm -rf ${TEMP_PATH}
     shell: bash


### PR DESCRIPTION
When the -f flag is provided, the program exits immediately with error 22 if the server fails to return a file for any reason.

I believe it would be reasonable to retry a few times to handle scenarios where the server is temporarily unavailable.