### PR TITLE
add taskOverride property (only supports `cpu` and `memory` field)

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -47,8 +47,8 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 					TaskOverride: &TaskOverride{
-						Cpu: "4096",
-						Memory: "16384",
+						Cpu:    aws.String("4096"),
+						Memory: aws.String("16384"),
 					},
 					ContainerOverrides: []*ContainerOverride{
 						{

--- a/config_test.go
+++ b/config_test.go
@@ -46,6 +46,10 @@ func TestLoadConfig(t *testing.T) {
 							AssignPublicIP: "ENABLED",
 						},
 					},
+					TaskOverride: &TaskOverride{
+						Cpu: "4096",
+						Memory: "16384",
+					},
 					ContainerOverrides: []*ContainerOverride{
 						{
 							Name: "container1",

--- a/rule.go
+++ b/rule.go
@@ -54,9 +54,8 @@ type CapacityProviderStrategyItem struct {
 }
 
 // NOTE: ContainerOverrides should conceptually be inside TaskOverride (cf. https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskOverride.html).
-// For backward-compatibility, we keep ContainerOverrides and TaskOverride
-// as separate fields and merge them into a single struct at apply time.
-// Only Cpu and Memory fields are supported yet.
+// However, for backward-compatibility, we keep ContainerOverrides and TaskOverride as separate fields and merge them into a single struct in `apply` and `run`.
+// That's why containerOverrides field is not inside TaskOverride.
 type TaskOverride struct {
 	Cpu    *string `yaml:"cpu,omitempty" json:"cpu,omitempty"`
 	Memory *string `yaml:"memory,omitempty" json:"memory,omitempty"`

--- a/rule.go
+++ b/rule.go
@@ -58,8 +58,8 @@ type CapacityProviderStrategyItem struct {
 // as separate fields and merge them into a single struct at apply time.
 // Only Cpu and Memory fields are supported yet.
 type TaskOverride struct {
-	Cpu    string `yaml:"cpu,omitempty" json:"cpu,omitempty"`
-	Memory string `yaml:"memory,omitempty" json:"memory,omitempty"`
+	Cpu    *string `yaml:"cpu,omitempty" json:"cpu,omitempty"`
+	Memory *string `yaml:"memory,omitempty" json:"memory,omitempty"`
 }
 
 // ContainerOverride overrides container
@@ -329,8 +329,8 @@ func (r *Rule) TagResourceInput() *cloudwatchevents.TagResourceInput {
 }
 
 type taskOverrideJSON struct {
-	Cpu                string                   `json:"cpu,omitempty"`
-	Memory             string                   `json:"memory,omitempty"`
+	Cpu                *string                  `json:"cpu,omitempty"`
+	Memory             *string                  `json:"memory,omitempty"`
 	ContainerOverrides []*containerOverrideJSON `json:"containerOverrides"`
 }
 
@@ -353,9 +353,9 @@ func (r *Rule) target() *cweTypes.Target {
 		return nil
 	}
 	toj := &taskOverrideJSON{}
-	if r.TaskOverride != nil {
-		toj.Cpu = r.TaskOverride.Cpu
-		toj.Memory = r.TaskOverride.Memory
+	if to := r.TaskOverride; to != nil {
+		toj.Cpu = to.Cpu
+		toj.Memory = to.Memory
 	}
 	for _, co := range r.ContainerOverrides {
 		var kvPairs []*kvPair
@@ -548,11 +548,9 @@ func (r *Rule) Run(ctx context.Context, awsConf aws.Config, noWait bool) error {
 	}
 
 	var taskOverride ecsTypes.TaskOverride
-	if r.TaskOverride != nil {
-		taskOverride = ecsTypes.TaskOverride{
-			Cpu:    aws.String(r.TaskOverride.Cpu),
-			Memory: aws.String(r.TaskOverride.Memory),
-		}
+	if to := r.TaskOverride; to != nil {
+		taskOverride.Cpu = to.Cpu
+		taskOverride.Memory = to.Memory
 	}
 	taskOverride.ContainerOverrides = containerOverrides
 

--- a/rule.go
+++ b/rule.go
@@ -34,6 +34,7 @@ type Target struct {
 	TargetID                 string                          `yaml:"targetId,omitempty" json:"targetId,omitempty"`
 	TaskDefinition           string                          `yaml:"taskDefinition" json:"taskDefinition"`
 	TaskCount                int32                           `yaml:"taskCount,omitempty" json:"taskCount,omitempty"`
+	TaskOverride             *TaskOverride                   `yaml:"taskOverride,omitempty" json:"taskOverride,omitempty"`
 	ContainerOverrides       []*ContainerOverride            `yaml:"containerOverrides,omitempty" json:"containerOverrides,omitempty"`
 	Role                     string                          `yaml:"role,omitempty" json:"role,omitempty"`
 	Group                    string                          `yaml:"group,omitempty" json:"group,omitempty"`
@@ -50,6 +51,15 @@ type CapacityProviderStrategyItem struct {
 	CapacityProvider string `yaml:"capacityProvider" json:"capacityProvider"`
 	Base             int32  `yaml:"base" json:"base"`
 	Weight           int32  `yaml:"weight" json:"weight"`
+}
+
+// NOTE: ContainerOverrides should conceptually be inside TaskOverride (cf. https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskOverride.html).
+// For backward-compatibility, we keep ContainerOverrides and TaskOverride
+// as separate fields and merge them into a single struct at apply time.
+// Only Cpu and Memory fields are supported yet.
+type TaskOverride struct {
+	Cpu                string               `yaml:"cpu,omitempty" json:"cpu,omitempty"`
+	Memory             string               `yaml:"memory,omitempty" json:"memory,omitempty"`
 }
 
 // ContainerOverride overrides container

--- a/rule.go
+++ b/rule.go
@@ -547,6 +547,15 @@ func (r *Rule) Run(ctx context.Context, awsConf aws.Config, noWait bool) error {
 		})
 	}
 
+	var taskOverride ecsTypes.TaskOverride
+	if r.TaskOverride != nil {
+		taskOverride = ecsTypes.TaskOverride{
+			Cpu:    aws.String(r.TaskOverride.Cpu),
+			Memory: aws.String(r.TaskOverride.Memory),
+		}
+	}
+	taskOverride.ContainerOverrides = containerOverrides
+
 	var networkConfiguration *ecsTypes.NetworkConfiguration
 	if r.NetworkConfiguration != nil {
 		networkConfiguration = r.NetworkConfiguration.inputParameters()
@@ -558,11 +567,9 @@ func (r *Rule) Run(ctx context.Context, awsConf aws.Config, noWait bool) error {
 
 	out, err := svc.RunTask(ctx,
 		&ecs.RunTaskInput{
-			Cluster:        aws.String(r.Cluster),
-			TaskDefinition: aws.String(r.taskDefinitionArn(r)),
-			Overrides: &ecsTypes.TaskOverride{
-				ContainerOverrides: containerOverrides,
-			},
+			Cluster:              aws.String(r.Cluster),
+			TaskDefinition:       aws.String(r.taskDefinitionArn(r)),
+			Overrides:            &taskOverride,
 			Count:                aws.Int32(r.taskCount()),
 			LaunchType:           ecsTypes.LaunchType(r.Target.LaunchType),
 			NetworkConfiguration: networkConfiguration,

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -89,10 +89,10 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 				return nil, err
 			}
 			if taskOv.Cpu != nil {
-				target.TaskOverride.Cpu = *taskOv.Cpu
+				target.TaskOverride.Cpu = taskOv.Cpu
 			}
 			if taskOv.Memory != nil {
-				target.TaskOverride.Memory = *taskOv.Memory
+				target.TaskOverride.Memory = taskOv.Memory
 			}
 			var contOverrides []*ContainerOverride
 			for _, co := range taskOv.ContainerOverrides {

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -88,12 +88,11 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 			if err := json.Unmarshal([]byte(*t.Input), taskOv); err != nil {
 				return nil, err
 			}
-			if taskOv.Cpu != nil {
-				target.TaskOverride.Cpu = taskOv.Cpu
+			taskOverride := &TaskOverride{
+				Cpu:    taskOv.Cpu,
+				Memory: taskOv.Memory,
 			}
-			if taskOv.Memory != nil {
-				target.TaskOverride.Memory = taskOv.Memory
-			}
+			target.TaskOverride = taskOverride
 			var contOverrides []*ContainerOverride
 			for _, co := range taskOv.ContainerOverrides {
 				var cmd []string

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -82,10 +82,17 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 			}
 		}
 
+		// For backward-compatibility, ContainerOverrides and TaskOverride are held as separate fields.
 		taskOv := &ecsTypes.TaskOverride{}
 		if t.Input != nil {
 			if err := json.Unmarshal([]byte(*t.Input), taskOv); err != nil {
 				return nil, err
+			}
+			if taskOv.Cpu != nil {
+				target.TaskOverride.Cpu = *taskOv.Cpu
+			}
+			if taskOv.Memory != nil {
+				target.TaskOverride.Memory = *taskOv.Memory
 			}
 			var contOverrides []*ContainerOverride
 			for _, co := range taskOv.ContainerOverrides {

--- a/testdata/sample.json
+++ b/testdata/sample.json
@@ -31,6 +31,10 @@
           "assign_public_ip": "ENABLED"
         }
       },
+      "taskOverride": {
+        "cpu": "4096",
+        "memory": "16384"
+      },
       "containerOverrides": [
         {
           "name": "container1",

--- a/testdata/sample.jsonnet
+++ b/testdata/sample.jsonnet
@@ -21,6 +21,10 @@ local envs = import 'envs.libsonnet';
         }
       ],
       "network_configuration": envs.network_configuration,
+      "taskOverride": {
+        "cpu": "4096",
+        "memory": "16384"
+      },
       "containerOverrides": [
         {
           "name": "container1",

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -22,6 +22,9 @@ rules:
       - sg-11111111
       - sg-99999999
       assign_public_ip: ENABLED
+  taskOverride:
+    cpu: "4096"
+    memory: "16384"
   containerOverrides:
   - name: container1
     command: ["subcmd", "argument"]


### PR DESCRIPTION
related issue: https://github.com/Songmu/ecschedule/issues/125

## What I implemented?

This pull request adds taskOverride support to ecschedule, allowing per-schedule CPU and memory overrides.

Note that:
- This PR does not support other fields in `taskOverride` like `taskRoleArn`.
- For backward compatibility, I keep ContainerOverrides and TaskOverride as separate fields. These fields are merged into a single struct when `apply` and `run`. So, `containerOverides` is not reflected when putting `containerOverides` inside `taskOverride` as below.
  ```
    rules:
  - name: hoge-task-name
    taskOverride:
      cpu: "4096"
      memory: "16384"
      containerOverrides:
      - name: container1
        command: ["subcmd", "argument"]
  ```
 
cf. https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskOverride.html

## test

### configuration

- `cpu` and `memory` in the utilized task definition is as below:
  - `cpu`: 1024
  - `memory`: 2048  
```
{
    "taskDefinitionArn": "arn:aws:ecs:ap-northeast-1:xxxx:task-definition/task1:2",
    "containerDefinitions": [
        {
            "name": "container1",
            "cpu": 0,
            ...
        }
    ],
 ...
    "cpu": "1024",
    "memory": "2048",
}
```

- The`taskOverride` configuration is added to `ecschedule.yaml` dumped by `ecschedule dump` command.

  ```
    region: ap-northeast-1
    cluster: ecschedule-test-cluster
    rules:
    - name: ecschedule-test
      scheduleExpression: rate(24 hours)
  -   targetId: made-in-aws-console
  +  targetId: scheduled-by-ecschedule
      taskDefinition: task1
      launch_type: FARGATE
      platform_version: LATEST
  +  taskOverride:
  +     cpu: 512
  +     memory: 1024
      network_configuration:
        aws_vpc_configuration:
          subnets:
          - subnet-xxx
          security_groups:
          - sg-xxx
          assign_public_ip: ENABLED
  
  ```

Then, I tested that `taskOverride` setting is reflected in `diff`, `apply`, and `run` command.

### `ecschedule diff`

The `taskOverride` setting is reflected in the output of the diff command.
![image](https://github.com/user-attachments/assets/268917ca-024b-439a-8e71-cdc92b20ef35)

### `ecschedule apply`

before apply:
<img width="1094" alt="image" src="https://github.com/user-attachments/assets/33f96c57-c15f-43a2-bae8-582fa4233f64" />

apply:
```
% ./ecschedule -conf ecschedule.yaml apply -rule ecschedule-test
[ecschedule] applying the rule "ecschedule-test"
[ecschedule] 💡 applying following changes
name: ecschedule-test
scheduleExpression: rate(24 hours)
targetId: maschedule-ind-awsby-econsochedule
taskDefinition: task1
taskOverride:
 {} cpu: "512"
  memory: "1024"
launch_type: FARGATE
platform_version: LATEST
network_configuration:
...
[ecschedule] ✅ following rule applied
name: ecschedule-test
scheduleExpression: rate(24 hours)
targetId: scheduled-by-ecschedule
taskDefinition: task1
taskOverride:
  cpu: "512"
  memory: "1024"
launch_type: FARGATE
platform_version: LATEST
network_configuration:
...
```

after apply: The `taskOverride` setting is reflected in schedule rules.
![image](https://github.com/user-attachments/assets/adb98a5d-a133-48fe-ad0e-d4f7031dc399)

### `ecschedule run`

run:
  ```
  % ./ecschedule -conf ecschedule.yaml run -rule ecschedule-test
  [ecschedule] running the rule "ecschedule-test"
  [ecschedule] ✅ ran the rule "ecschedule-test"
  ```

The taskOverride settings (cpu: 512, memory: 1024) specified in ecschedule is reflected in the task configuration as below.
![image](https://github.com/user-attachments/assets/6a50df63-2e8c-42cb-87e5-0668871e8ebd)


