### PR TITLE
fix: set app context before loading config to prevent nil pointer dereference

### DIFF
--- a/ecsched.go
+++ b/ecsched.go
@@ -49,6 +49,7 @@ func Run(ctx context.Context, argv []string, outStream, errStream io.Writer) err
 		AccountID: accountID,
 		AwsConf:   awsConf,
 	}
+	ctx = setApp(ctx, a)
 	if *conf != "" {
 		f, err := os.Open(*conf)
 		if err != nil {


### PR DESCRIPTION
## Summary
This PR fixes a nil pointer dereference that occurs when running ecschedule with a config file.

## Problem
When running ecschedule v0.15.0 (rev:e7e55a8) with the `-conf` flag, the application panics with:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104335f6c]

goroutine 1 [running]:
github.com/Songmu/ecschedule.setupPluginSSM({0x104d27740, 0x105fccf80}, {{0x140001847a4, 0x3}, 0x140005325a0, {0x0, 0x0}}, 0x1400040e070)
	github.com/Songmu/ecschedule/plugin.go:63 +0x5c
github.com/Songmu/ecschedule.Plugin.setup({{0x140001847a4, 0x3}, 0x140005325a0, {0x0, 0x0}}, {0x104d27740, 0x105fccf80}, 0x1400040e070)
	github.com/Songmu/ecschedule/plugin.go:27 +0x88
github.com/Songmu/ecschedule.(*Config).setupPlugins(0x1400040e070, {0x104d27740, 0x105fccf80})
	github.com/Songmu/ecschedule/config.go:57 +0xb8
github.com/Songmu/ecschedule.LoadConfig({0x104d27740, 0x105fccf80}, {0x104cf3c80, 0x14000398038}, {0x140001842c0, 0xc}, {0x16cf42cc9, 0x24})
	github.com/Songmu/ecschedule/config.go:121 +0x120
github.com/Songmu/ecschedule.Run({0x104d27740, 0x105fccf80}, {0x140001c4010, 0x4, 0x4}, {0x104cf3ab8, 0x1400018e038}, {0x104cf3ab8, 0x1400018e040})
	github.com/Songmu/ecschedule/ecsched.go:58 +0x534
main.main()
	github.com/Songmu/ecschedule/cmd/ecschedule/main.go:14 +0xa0
```

The panic occurs in `setupPluginSSM` at plugin.go:63 when it tries to access the app from the context.

## Solution
The issue is that `setApp(ctx, a)` was being called after `LoadConfig`, but `LoadConfig` needs the app context during plugin setup. This PR moves the `setApp` call to before the config loading section.

## Changes
- Move `ctx = setApp(ctx, a)` to line 52, before the config loading logic
- This ensures the app is available in the context when plugins are being set up

## Testing
After this change, the command runs successfully without panic.