### PR TITLE
fix: handle nil ScheduleExpression to prevent panic

### DIFF
--- a/rule_getter.go
+++ b/rule_getter.go
@@ -126,10 +126,14 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 	if r.Description != nil {
 		desc = *r.Description
 	}
+	var expr string
+	if r.ScheduleExpression != nil {
+		expr = *r.ScheduleExpression
+	}
 	ru := &Rule{
 		Name:               *r.Name,
 		Description:        desc,
-		ScheduleExpression: *r.ScheduleExpression,
+		ScheduleExpression: expr,
 		Disabled:           string(r.State) == "DISABLED",
 	}
 	switch len(targets) {


### PR DESCRIPTION
 ## 概要
  EventBridge ルールの `ScheduleExpression` が nil の場合にパニックが発生する問題を修正しました。

  ## 問題
  #26 で報告されているように、古いEventBridgeルールなど、`ScheduleExpression` が設定されていないルールが存在する場合、`ecschedule dump`
  コマンドを実行すると以下のエラーが発生していました：

  panic: runtime error: invalid memory address or nil pointer dereference

  ## 修正内容
  `rule_getter.go` の `getRule` メソッドで、`r.ScheduleExpression` を直接デリファレンスする前に nil チェックを追加しました。nil の場合は空文字列を設定するようにしています。

  ```go
  var expr string
  if r.ScheduleExpression != nil {
      expr = *r.ScheduleExpression
  }

  この修正により、ScheduleExpression が未設定のルールが存在してもパニックが発生せず、正常に処理が継続されるようになります。

  関連 Issue

  Partially fixes #26

  この変更により、古いEventBridgeルールや何らかの理由で `ScheduleExpression` が設定されていないルールが存在する環境でも、安全に `ecschedule dump` コマンドを実行できるようになります。