### PR TITLE
feat(apply): add `-parallel` flag for dry-run parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,17 @@ This performs the same validation as `apply` and `run`, with a slight overhead, 
 
 ### Parallel Execution
 
-The `diff` command supports parallel execution for improved performance with many rules:
+The `diff` command and `apply -dry-run` support parallel execution for improved performance with many rules:
 
 ```console
 % ecschedule -conf ecschedule.yaml diff -all -parallel 10
+% ecschedule -conf ecschedule.yaml apply -all -dry-run -parallel 10
 ```
 
 - Default: `parallel=1` (sequential, backward compatible)
 - Recommended: 1-10 (due to AWS API rate limits)
 - Note: Output order is not guaranteed when parallel > 1
+- Note: `-parallel` is only effective with `-dry-run` for the `apply` command. Using it without `-dry-run` returns an error.
 
 ## Log Format
 

--- a/cmd_apply.go
+++ b/cmd_apply.go
@@ -12,6 +12,11 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
+type applyDryRunResult struct {
+	ruleName string
+	ruleYaml string
+}
+
 var cmdApply = &runnerImpl{
 	name:        "apply",
 	description: "apply the rule",
@@ -19,13 +24,14 @@ var cmdApply = &runnerImpl{
 		fs := flag.NewFlagSet("ecschedule apply", flag.ContinueOnError)
 		fs.SetOutput(errStream)
 		var (
-			conf    = fs.String("conf", "", "configuration")
-			rule    = fs.String("rule", "", "rule")
-			dryRun  = fs.Bool("dry-run", false, "dry run")
-			all     = fs.Bool("all", false, "apply all rules")
-			prune   = fs.Bool("prune", false, "prune orphaned rules after apply")
-			unified = fs.Bool("u", false, "output diff in unified format (colored, similar to git diff)")
-			noColor = fs.Bool("no-color", false, "disable colored output (Unified diff format only)")
+			conf     = fs.String("conf", "", "configuration")
+			rule     = fs.String("rule", "", "rule")
+			dryRun   = fs.Bool("dry-run", false, "dry run")
+			all      = fs.Bool("all", false, "apply all rules")
+			prune    = fs.Bool("prune", false, "prune orphaned rules after apply")
+			unified  = fs.Bool("u", false, "output diff in unified format (colored, similar to git diff)")
+			noColor  = fs.Bool("no-color", false, "disable colored output (Unified diff format only)")
+			parallel = fs.Int("parallel", 1, "number of parallel workers for dry-run (default: 1, only effective with -dry-run, recommended: 1-10 due to AWS API rate limits. Note: output order is not guaranteed when parallel > 1)")
 		)
 		if err := fs.Parse(argv); err != nil {
 			return err
@@ -62,6 +68,13 @@ var cmdApply = &runnerImpl{
 			}
 		}
 
+		if *parallel < 1 {
+			return errors.New("-parallel must be at least 1")
+		}
+		if *parallel > 1 && !*dryRun {
+			return errors.New("-parallel can only be used with -dry-run (apply parallelization is not yet supported)")
+		}
+
 		var dryRunSuffix string
 		if *dryRun {
 			dryRunSuffix = " (dry-run)"
@@ -69,21 +82,46 @@ var cmdApply = &runnerImpl{
 
 		format := selectDiffFormat(*unified)
 
-		for _, rule := range ruleNames {
-			ru := c.GetRuleByName(rule)
-			if ru == nil {
-				return fmt.Errorf("no rules found for %s", rule)
+		if *dryRun {
+			processApplyDryRunJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+				ru := c.GetRuleByName(ruleName)
+				if ru == nil {
+					return applyDryRunResult{}, fmt.Errorf("no rules found for %s", ruleName)
+				}
+				log.Printf("applying the rule %q%s", ruleName, dryRunSuffix)
+				if err := ru.applyInternal(ctx, a.AwsConf, true, format); err != nil {
+					return applyDryRunResult{}, err
+				}
+				for _, v := range ru.ContainerOverrides {
+					v.Environment = nil
+				}
+				bs, _ := yaml.Marshal(ru)
+				return applyDryRunResult{ruleName: ruleName, ruleYaml: string(bs)}, nil
 			}
-			log.Printf("applying the rule %q%s", rule, dryRunSuffix)
-			if err := ru.applyInternal(ctx, a.AwsConf, *dryRun, format); err != nil {
+
+			results, errChan := executeJobsInParallel[applyDryRunResult](ctx, ruleNames, *parallel, processApplyDryRunJob)
+			for result := range results {
+				log.Printf("✅ following rule applied%s\n%s", dryRunSuffix, result.ruleYaml)
+			}
+			if err := <-errChan; err != nil {
 				return err
 			}
-			for _, v := range ru.ContainerOverrides {
-				// mask environment variables
-				v.Environment = nil
+		} else {
+			for _, rule := range ruleNames {
+				ru := c.GetRuleByName(rule)
+				if ru == nil {
+					return fmt.Errorf("no rules found for %s", rule)
+				}
+				log.Printf("applying the rule %q", rule)
+				if err := ru.applyInternal(ctx, a.AwsConf, false, format); err != nil {
+					return err
+				}
+				for _, v := range ru.ContainerOverrides {
+					v.Environment = nil
+				}
+				bs, _ := yaml.Marshal(ru)
+				log.Printf("✅ following rule applied\n%s", string(bs))
 			}
-			bs, _ := yaml.Marshal(ru)
-			log.Printf("✅ following rule applied%s\n%s", dryRunSuffix, string(bs))
 		}
 
 		if *prune {

--- a/cmd_apply_test.go
+++ b/cmd_apply_test.go
@@ -1,0 +1,257 @@
+package ecschedule
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestExecuteApplyDryRunJobsInParallel(t *testing.T) {
+	t.Run("parallel=1 executes jobs sequentially", func(t *testing.T) {
+		var executionOrder []string
+		var mu sync.Mutex
+
+		mockJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+			mu.Lock()
+			executionOrder = append(executionOrder, ruleName)
+			mu.Unlock()
+
+			return applyDryRunResult{
+				ruleName: ruleName,
+				ruleYaml: fmt.Sprintf("yaml for %s", ruleName),
+			}, nil
+		}
+
+		results, errChan := executeJobsInParallel[applyDryRunResult](
+			context.Background(),
+			[]string{"rule1", "rule2", "rule3"},
+			1,
+			mockJob,
+		)
+
+		var collected []applyDryRunResult
+		for result := range results {
+			collected = append(collected, result)
+		}
+
+		err := <-errChan
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(collected) != 3 {
+			t.Errorf("expected 3 results, got %d", len(collected))
+		}
+
+		if len(executionOrder) != 3 {
+			t.Errorf("expected 3 executions, got %d", len(executionOrder))
+		}
+	})
+
+	t.Run("parallel>1 executes jobs concurrently", func(t *testing.T) {
+		var executedCount atomic.Int32
+		jobCount := 20
+
+		mockJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+			executedCount.Add(1)
+			time.Sleep(10 * time.Millisecond)
+
+			return applyDryRunResult{
+				ruleName: ruleName,
+				ruleYaml: fmt.Sprintf("yaml for %s", ruleName),
+			}, nil
+		}
+
+		ruleNames := make([]string, jobCount)
+		for i := 0; i < jobCount; i++ {
+			ruleNames[i] = fmt.Sprintf("rule-%d", i)
+		}
+
+		results, errChan := executeJobsInParallel[applyDryRunResult](
+			context.Background(),
+			ruleNames,
+			5,
+			mockJob,
+		)
+
+		var collected []applyDryRunResult
+		for result := range results {
+			collected = append(collected, result)
+		}
+
+		err := <-errChan
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(collected) != jobCount {
+			t.Errorf("expected %d results, got %d", jobCount, len(collected))
+		}
+
+		if executedCount.Load() != int32(jobCount) {
+			t.Errorf("expected %d executions, got %d", jobCount, executedCount.Load())
+		}
+	})
+
+	t.Run("handles job errors", func(t *testing.T) {
+		errorRuleName := "rule-error"
+
+		mockJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+			if ruleName == errorRuleName {
+				return applyDryRunResult{}, fmt.Errorf("simulated error for %s", ruleName)
+			}
+
+			return applyDryRunResult{
+				ruleName: ruleName,
+				ruleYaml: fmt.Sprintf("yaml for %s", ruleName),
+			}, nil
+		}
+
+		results, errChan := executeJobsInParallel[applyDryRunResult](
+			context.Background(),
+			[]string{"rule1", errorRuleName, "rule3"},
+			2,
+			mockJob,
+		)
+
+		var collected []applyDryRunResult
+		for result := range results {
+			collected = append(collected, result)
+		}
+
+		err := <-errChan
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "simulated error") {
+			t.Errorf("expected error to contain 'simulated error', got: %v", err)
+		}
+
+		_ = collected
+	})
+
+	t.Run("handles panic in jobs", func(t *testing.T) {
+		panicRuleName := "rule-panic"
+
+		mockJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+			if ruleName == panicRuleName {
+				panic("simulated panic")
+			}
+
+			return applyDryRunResult{
+				ruleName: ruleName,
+				ruleYaml: fmt.Sprintf("yaml for %s", ruleName),
+			}, nil
+		}
+
+		results, errChan := executeJobsInParallel[applyDryRunResult](
+			context.Background(),
+			[]string{"rule1", panicRuleName, "rule3"},
+			2,
+			mockJob,
+		)
+
+		var collected []applyDryRunResult
+		for result := range results {
+			collected = append(collected, result)
+		}
+
+		err := <-errChan
+		if err == nil {
+			t.Fatal("expected error due to panic, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "failed due to panic") {
+			t.Errorf("expected panic error, got: %v", err)
+		}
+
+		if len(collected) != 2 {
+			t.Errorf("expected 2 results (non-panic jobs), got %d", len(collected))
+		}
+	})
+
+	t.Run("context cancellation stops workers", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var executedCount atomic.Int32
+
+		mockJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+			executedCount.Add(1)
+
+			if executedCount.Load() == 2 {
+				cancel()
+			}
+
+			select {
+			case <-ctx.Done():
+				return applyDryRunResult{}, ctx.Err()
+			case <-time.After(100 * time.Millisecond):
+				return applyDryRunResult{
+					ruleName: ruleName,
+					ruleYaml: fmt.Sprintf("yaml for %s", ruleName),
+				}, nil
+			}
+		}
+
+		results, errChan := executeJobsInParallel[applyDryRunResult](
+			ctx,
+			[]string{"rule1", "rule2", "rule3", "rule4", "rule5"},
+			2,
+			mockJob,
+		)
+
+		var collected []applyDryRunResult
+		for result := range results {
+			collected = append(collected, result)
+		}
+
+		err := <-errChan
+		if err == nil {
+			t.Fatal("expected error due to context cancellation, got nil")
+		}
+
+		if len(collected) >= 5 {
+			t.Errorf("expected fewer than 5 results due to cancellation, got %d", len(collected))
+		}
+	})
+
+	t.Run("all rules are processed", func(t *testing.T) {
+		jobCount := 10
+		ruleNames := make([]string, jobCount)
+		for i := 0; i < jobCount; i++ {
+			ruleNames[i] = fmt.Sprintf("rule-%d", i)
+		}
+
+		mockJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
+			return applyDryRunResult{
+				ruleName: ruleName,
+				ruleYaml: fmt.Sprintf("yaml for %s", ruleName),
+			}, nil
+		}
+
+		results, errChan := executeJobsInParallel[applyDryRunResult](
+			context.Background(),
+			ruleNames,
+			3,
+			mockJob,
+		)
+
+		var collected []applyDryRunResult
+		for result := range results {
+			collected = append(collected, result)
+		}
+
+		err := <-errChan
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(collected) != jobCount {
+			t.Errorf("expected %d results, got %d", jobCount, len(collected))
+		}
+	})
+}

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -8,74 +8,16 @@ import (
 	"io"
 	"log"
 	"os"
-	"runtime/debug"
 	"sync/atomic"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
 	"github.com/goccy/go-yaml"
-	"golang.org/x/sync/errgroup"
 )
 
 type diffResult struct {
 	ruleName         string
 	diffOutput       string
 	validationErrors []string
-}
-
-func executeDiffJobsInParallel(
-	ctx context.Context,
-	ruleNames []string,
-	parallel int,
-	jobFunc func(ctx context.Context, ruleName string) (diffResult, error),
-) (<-chan diffResult, <-chan error) {
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(parallel)
-
-	results := make(chan diffResult, len(ruleNames))
-	errChan := make(chan error, 1)
-	var panicCount atomic.Int32
-
-	for _, ruleName := range ruleNames {
-		ruleName := ruleName
-		g.Go(func() error {
-			defer func() {
-				if rec := recover(); rec != nil {
-					panicCount.Add(1)
-					log.Printf("[ERROR] panic in worker for rule %q: %v\n%s",
-						ruleName, rec, debug.Stack())
-				}
-			}()
-
-			result, err := jobFunc(ctx, ruleName)
-			if err != nil {
-				return err
-			}
-
-			select {
-			case results <- result:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-
-			return nil
-		})
-	}
-
-	go func() {
-		err := g.Wait()
-		close(results)
-
-		if err != nil {
-			errChan <- err
-		} else if count := panicCount.Load(); count > 0 {
-			errChan <- fmt.Errorf("%d rule(s) failed due to panic (see logs above for details)", count)
-		} else {
-			errChan <- nil
-		}
-		close(errChan)
-	}()
-
-	return results, errChan
 }
 
 var cmdDiff = &runnerImpl{
@@ -180,7 +122,7 @@ var cmdDiff = &runnerImpl{
 			return result, nil
 		}
 
-		results, errChan := executeDiffJobsInParallel(ctx, ruleNames, *parallel, processDiffJob)
+		results, errChan := executeJobsInParallel[diffResult](ctx, ruleNames, *parallel, processDiffJob)
 
 		for result := range results {
 			if len(result.validationErrors) > 0 {

--- a/cmd_diff_test.go
+++ b/cmd_diff_test.go
@@ -26,7 +26,7 @@ func TestExecuteDiffJobsInParallel(t *testing.T) {
 			}, nil
 		}
 
-		results, errChan := executeDiffJobsInParallel(
+		results, errChan := executeJobsInParallel[diffResult](
 			context.Background(),
 			[]string{"rule1", "rule2", "rule3"},
 			1,
@@ -71,7 +71,7 @@ func TestExecuteDiffJobsInParallel(t *testing.T) {
 			ruleNames[i] = fmt.Sprintf("rule-%d", i)
 		}
 
-		results, errChan := executeDiffJobsInParallel(
+		results, errChan := executeJobsInParallel[diffResult](
 			context.Background(),
 			ruleNames,
 			5,
@@ -111,7 +111,7 @@ func TestExecuteDiffJobsInParallel(t *testing.T) {
 			}, nil
 		}
 
-		results, errChan := executeDiffJobsInParallel(
+		results, errChan := executeJobsInParallel[diffResult](
 			context.Background(),
 			[]string{"rule1", errorRuleName, "rule3"},
 			2,
@@ -147,7 +147,7 @@ func TestExecuteDiffJobsInParallel(t *testing.T) {
 			}, nil
 		}
 
-		results, errChan := executeDiffJobsInParallel(
+		results, errChan := executeJobsInParallel[diffResult](
 			context.Background(),
 			[]string{"rule1", panicRuleName, "rule3"},
 			2,
@@ -195,7 +195,7 @@ func TestExecuteDiffJobsInParallel(t *testing.T) {
 			}
 		}
 
-		results, errChan := executeDiffJobsInParallel(
+		results, errChan := executeJobsInParallel[diffResult](
 			ctx,
 			[]string{"rule1", "rule2", "rule3", "rule4", "rule5"},
 			2,
@@ -231,7 +231,7 @@ func TestExecuteDiffJobsInParallel(t *testing.T) {
 			return result, nil
 		}
 
-		results, errChan := executeDiffJobsInParallel(
+		results, errChan := executeJobsInParallel[diffResult](
 			context.Background(),
 			[]string{"rule1", "rule2-invalid", "rule3"},
 			2,

--- a/parallel.go
+++ b/parallel.go
@@ -1,0 +1,67 @@
+package ecschedule
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func executeJobsInParallel[T any](
+	ctx context.Context,
+	ruleNames []string,
+	parallel int,
+	jobFunc func(ctx context.Context, ruleName string) (T, error),
+) (<-chan T, <-chan error) {
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(parallel)
+
+	results := make(chan T, len(ruleNames))
+	errChan := make(chan error, 1)
+	var panicCount atomic.Int32
+
+	for _, ruleName := range ruleNames {
+		ruleName := ruleName
+		g.Go(func() error {
+			defer func() {
+				if rec := recover(); rec != nil {
+					panicCount.Add(1)
+					log.Printf("[ERROR] panic in worker for rule %q: %v\n%s",
+						ruleName, rec, debug.Stack())
+				}
+			}()
+
+			result, err := jobFunc(ctx, ruleName)
+			if err != nil {
+				return err
+			}
+
+			select {
+			case results <- result:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			return nil
+		})
+	}
+
+	go func() {
+		err := g.Wait()
+		close(results)
+
+		if err != nil {
+			errChan <- err
+		} else if count := panicCount.Load(); count > 0 {
+			errChan <- fmt.Errorf("%d rule(s) failed due to panic (see logs above for details)", count)
+		} else {
+			errChan <- nil
+		}
+		close(errChan)
+	}()
+
+	return results, errChan
+}


### PR DESCRIPTION
## Background

When managing a large number of rules, `apply -dry-run` used as a CI pre-deployment check becomes slow — each rule requires multiple sequential AWS API calls, making CI feedback noticeably slow.

## Summary

Add `-parallel` flag to `apply -dry-run` for significant speedup when managing large rule sets.

`apply -dry-run` calls multiple AWS APIs per rule (EventBridge `DescribeRule` + `ListTargetsByRule`, ECS `DescribeTaskDefinition`) — the same bottleneck that `-parallel` addressed in the `diff` command (#208).

## Performance (150 rules)

| Command | real time | Speedup |
|---------|-----------|---------|
| `apply -all -dry-run` (default) | 34.3s | - |
| `apply -all -dry-run -parallel 5` | 7.4s | **4.6x** |
| `apply -all -dry-run -parallel 10` | 4.2s | **8.1x** |

## Why dry-run only?

For the same reasons described in #208 ("Why diff first?"). Full `apply` introduces partial-failure risk with parallel writes, which requires separate careful evaluation.

The following usages return an error to make this boundary explicit:

```
# -parallel without -dry-run
$ ecschedule apply -all -parallel 5 -conf config.yaml
[ecschedule] 💢 -parallel can only be used with -dry-run (apply parallelization is not yet supported)

# -parallel 0 or negative
$ ecschedule apply -all -dry-run -parallel 0 -conf config.yaml
[ecschedule] 💢 -parallel must be at least 1
```

## Implementation

- Generalized `executeDiffJobsInParallel` → `executeJobsInParallel[T any]` (Go generics) in a new `parallel.go`, shared between `diff` and `apply -dry-run`
- `diff` behavior is unchanged; it now calls `executeJobsInParallel[diffResult]`
- New `applyDryRunResult` type captures per-rule output for the parallel path

## Backward Compatibility

✅ Default is `-parallel 1` — no behavior change  
✅ No breaking changes to existing commands or flags