### PR TITLE
Fix diff flapping when role is unchanged (#61)

### DIFF
--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -97,7 +97,6 @@ var cmdDump = &runnerImpl{
 				clusterArn:       fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", *region, accountID, *cluster),
 				taskDefArnPrefix: fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/", *region, accountID),
 				roleArnPrefix:    roleArnPrefix,
-				roleArn:          fmt.Sprintf("%s%s", roleArnPrefix, *role),
 				sqsArnPrefix:     fmt.Sprintf("arn:aws:sqs:%s:%s:", *region, accountID),
 			}
 		)

--- a/rule.go
+++ b/rule.go
@@ -166,6 +166,7 @@ func NewRuleFromRemote(ctx context.Context, awsConf aws.Config, bc *BaseConfig, 
 			ruleArnPrefix:    fmt.Sprintf("arn:aws:events:%s:%s:rule/", bc.Region, bc.AccountID),
 			clusterArn:       fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", bc.Region, bc.AccountID, bc.Cluster),
 			taskDefArnPrefix: fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/", bc.Region, bc.AccountID),
+			roleArnPrefix:    fmt.Sprintf("arn:aws:iam::%s:role/", bc.AccountID),
 		}
 	)
 
@@ -638,22 +639,38 @@ func (r *Rule) deleteInternal(ctx context.Context, awsConf aws.Config, dryRun bo
 	return err
 }
 
+// localYAMLForDiff returns the YAML representation of r used as the "to" side
+// of (*Rule).diff. It strips BaseConfig and normalizes an empty Role to
+// defaultRole so the output stays symmetric with the YAML reconstructed from
+// the remote rule (which always carries a resolved role).
+func (r *Rule) localYAMLForDiff() (string, error) {
+	bc := r.BaseConfig
+	r.BaseConfig = nil
+	defer func() { r.BaseConfig = bc }()
+
+	origRole := r.Role
+	if r.Role == "" {
+		r.Role = defaultRole
+	}
+	defer func() { r.Role = origRole }()
+
+	bs, err := yaml.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}
+
 func (r *Rule) diff(ctx context.Context, cw *cloudwatchevents.Client) (from, to string, err error) {
 	rule := aws.String(r.Name)
 
 	c := r.BaseConfig
-	r.BaseConfig = nil
-	defer func() { r.BaseConfig = c }()
-	bs, err := yaml.Marshal(r)
+
+	localRuleYaml, err := r.localYAMLForDiff()
 	if err != nil {
 		return "", "", err
 	}
-	localRuleYaml := string(bs)
 
-	role := r.Role
-	if role == "" {
-		role = defaultRole
-	}
 	ruleList, err := cw.ListRules(ctx, &cloudwatchevents.ListRulesInput{
 		NamePrefix: rule,
 	})
@@ -669,7 +686,6 @@ func (r *Rule) diff(ctx context.Context, cw *cloudwatchevents.Client) (from, to 
 			clusterArn:       fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", c.Region, c.AccountID, c.Cluster),
 			taskDefArnPrefix: fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/", c.Region, c.AccountID),
 			roleArnPrefix:    roleArnPrefix,
-			roleArn:          fmt.Sprintf("%s%s", roleArnPrefix, role),
 		}
 		remoteRuleYaml string
 	)

--- a/rule_getter.go
+++ b/rule_getter.go
@@ -12,8 +12,8 @@ import (
 )
 
 type ruleGetter struct {
-	svc                                                                               *cloudwatchevents.Client
-	clusterArn, ruleArnPrefix, taskDefArnPrefix, roleArnPrefix, roleArn, sqsArnPrefix string
+	svc                                                                      *cloudwatchevents.Client
+	clusterArn, ruleArnPrefix, taskDefArnPrefix, roleArnPrefix, sqsArnPrefix string
 }
 
 func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, error) {
@@ -43,9 +43,10 @@ func (rg *ruleGetter) getRule(ctx context.Context, r *cweTypes.Rule) (*Rule, err
 		}
 		target := &Target{TargetID: targetID}
 
-		if role := *t.RoleArn; role != rg.roleArn {
-			target.Role = strings.TrimPrefix(role, rg.roleArnPrefix)
-		}
+		// Always populate Role to keep the dumped/remote YAML symmetric with
+		// the local configuration, which always specifies a role explicitly
+		// (or implicitly via the default).
+		target.Role = strings.TrimPrefix(*t.RoleArn, rg.roleArnPrefix)
 
 		taskCount := *ecsParams.TaskCount
 		if taskCount != 1 {

--- a/rule_role_test.go
+++ b/rule_role_test.go
@@ -1,0 +1,76 @@
+package ecschedule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRule_LocalYAMLForDiff_NormalizesEmptyRole(t *testing.T) {
+	bc := &BaseConfig{
+		Region:    "ap-northeast-1",
+		Cluster:   "default",
+		AccountID: "123456789012",
+	}
+
+	withEmptyRole := &Rule{
+		Name:               "hello-world",
+		ScheduleExpression: "cron(0 0 1 * ? *)",
+		Target: &Target{
+			TaskDefinition: "hello-world:1",
+		},
+		BaseConfig: bc,
+	}
+	withDefaultRole := &Rule{
+		Name:               "hello-world",
+		ScheduleExpression: "cron(0 0 1 * ? *)",
+		Target: &Target{
+			TaskDefinition: "hello-world:1",
+			Role:           defaultRole,
+		},
+		BaseConfig: bc,
+	}
+
+	gotEmpty, err := withEmptyRole.localYAMLForDiff()
+	if err != nil {
+		t.Fatalf("localYAMLForDiff (empty role): %v", err)
+	}
+	gotDefault, err := withDefaultRole.localYAMLForDiff()
+	if err != nil {
+		t.Fatalf("localYAMLForDiff (default role): %v", err)
+	}
+
+	if gotEmpty != gotDefault {
+		t.Errorf("YAML for empty role and default role should match.\nempty:\n%s\ndefault:\n%s", gotEmpty, gotDefault)
+	}
+
+	if !strings.Contains(gotEmpty, "role: "+defaultRole) {
+		t.Errorf("expected normalized YAML to contain %q, got:\n%s", "role: "+defaultRole, gotEmpty)
+	}
+}
+
+func TestRule_LocalYAMLForDiff_PreservesExplicitRole(t *testing.T) {
+	bc := &BaseConfig{
+		Region:    "ap-northeast-1",
+		Cluster:   "default",
+		AccountID: "123456789012",
+	}
+
+	const explicit = "service-role/AWS_Events_Invoke_Hello_World"
+	r := &Rule{
+		Name:               "hello-world",
+		ScheduleExpression: "cron(0 0 1 * ? *)",
+		Target: &Target{
+			TaskDefinition: "hello-world:1",
+			Role:           explicit,
+		},
+		BaseConfig: bc,
+	}
+
+	got, err := r.localYAMLForDiff()
+	if err != nil {
+		t.Fatalf("localYAMLForDiff: %v", err)
+	}
+	if !strings.Contains(got, "role: "+explicit) {
+		t.Errorf("expected YAML to preserve explicit role %q, got:\n%s", explicit, got)
+	}
+}


### PR DESCRIPTION
Fixes #61

`ecschedule diff` always shows a diff even when `role` hasn't changed.

The local and remote YAMLs being string-compared were asymmetric on `role`: the remote side cleared `target.Role` whenever `RoleArn` matched the locally-derived ARN, so the remote YAML lost its `role:` line while the local YAML kept it. Same role, but always reported as a diff.

The fix is to make both sides always emit `role`:

- `ruleGetter.getRule`: drop the conditional and always set `target.Role = TrimPrefix(*t.RoleArn, roleArnPrefix)`.
- Pull the local YAML generation in `Rule.diff` into `localYAMLForDiff`, and normalize empty `Role` to `defaultRole` before marshalling. Original value is restored via `defer`, so no side effects on the receiver.
- Drop the now-unused `ruleGetter.roleArn` field (and its initializers in `cmd_dump.go` / `rule.go`).
- Set `roleArnPrefix` in the `ruleGetter` built by `NewRuleFromRemote`. It was missing on this path; the old conditional happened to hide it, but with `target.Role` now always populated, a missing prefix would leak the full ARN into `target.Role`.

Based on the minimal patch suggested in the #61 comment, plus the local-side normalization and the missing `roleArnPrefix`.

Note: `ecschedule dump` will now always emit `role:` per rule (it used to be omitted when matching the top-level `role`). The output is still semantically equivalent on reload, and `apply` behavior is unchanged.

