### PR TITLE
Use tcnksm/ghr GitHub Action for release uploads

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -14,9 +14,12 @@ runs:
     uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
     with:
       go-version-file: go.mod
-  - name: release
-    run: |
-      make crossbuild upload
+  - name: crossbuild
+    run: make crossbuild
     shell: bash
-    env:
-      GITHUB_TOKEN: ${{ inputs.token }}
+  - name: upload
+    uses: tcnksm/ghr@766f869eacbbb086e8860cf0f0192dda6e8e67e1 # v0.18.3
+    with:
+      tag: ${{ inputs.tag || github.ref_name }}
+      path: dist
+      token: ${{ inputs.token }}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ deps:
 
 .PHONY: devel-deps
 devel-deps:
-	go install github.com/tcnksm/ghr@latest
 	go install github.com/Songmu/godzil/cmd/godzil@latest
 
 .PHONY: test
@@ -37,7 +36,3 @@ crossbuild: go.sum devel-deps
 	godzil crossbuild -pv=v$(VERSION) -build-ldflags=$(BUILD_LDFLAGS) \
       -os=linux,darwin,windows -d=$(DIST_DIR) ./cmd/*
 	cd $(DIST_DIR) && shasum -a 256 $$(find * -type f -maxdepth 0) > SHA256SUMS
-
-.PHONY: upload
-upload:
-	ghr v$(VERSION) $(DIST_DIR)


### PR DESCRIPTION
Replace the ghr CLI tool with the tcnksm/ghr composite action (v0.18.3) for uploading release artifacts. This removes the need to install ghr via go install and simplifies the release workflow.