### PR TITLE
Add must_env and env native functions for Jsonnet configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ trackingId: trackingId1
     command: [subcommand2, arg]
 ```
 
+### Environment variables in Jsonnet (native functions)
+
+When using a `.jsonnet` config, the following native functions are available at evaluation time:
+
+- `std.native('must_env')(name)` — returns the value of env var `name`; errors if the variable is not set.
+- `std.native('env')(name, default)` — returns the value of env var `name`, or `default` if unset.
+
+Use these when you need to derive a non-string field (e.g., `disabled: bool`) from an env variable. The Go template helper `{{ must_env "..." }}` only substitutes inside string values after Jsonnet evaluation, so it cannot set boolean / numeric fields.
+
+Example — disable all rules in production while keeping them enabled in development:
+
+```jsonnet
+local isProd = std.native('must_env')('ENV') == 'prod';
+{
+  region: 'ap-northeast-1',
+  cluster: '{{ must_env `ENV` }}-cluster',
+  rules: [
+    {
+      name: 'my-rule',
+      scheduleExpression: 'rate(1 hour)',
+      taskDefinition: 'my-task',
+      disabled: isProd,
+      containerOverrides: [],
+    },
+  ],
+}
+```
+
 ## Installation
 
 ```console

--- a/config.go
+++ b/config.go
@@ -11,7 +11,6 @@ import (
 	"text/template"
 
 	"github.com/goccy/go-yaml"
-	"github.com/google/go-jsonnet"
 	gc "github.com/kayac/go-config"
 	"github.com/winebarrel/cronplan"
 )
@@ -156,7 +155,7 @@ func unmarshalConfig(bs []byte, c *Config, ext string) error {
 func readConfigFile(r io.Reader, confPath string) ([]byte, string, error) {
 	ext := filepath.Ext(confPath)
 	if ext == jsonnetExt {
-		vm := jsonnet.MakeVM()
+		vm := newJsonnetVM()
 		bs, err := vm.EvaluateFile(confPath)
 		if err != nil {
 			return nil, ext, fmt.Errorf("failed to evaluate jsonnet file: %w", err)

--- a/jsonnet.go
+++ b/jsonnet.go
@@ -1,0 +1,55 @@
+package ecschedule
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/ast"
+)
+
+// newJsonnetVM creates a jsonnet VM with native functions registered for
+// accessing OS environment variables at jsonnet evaluation time.
+//
+// Registered native functions:
+//   - must_env(name):     returns env var `name`; errors if unset.
+//   - env(name, default): returns env var `name`, or `default` if unset.
+//
+// These mirror the Go template helpers in template.go. They are required
+// for setting non-string fields (e.g., `disabled: bool`) conditionally per
+// environment, which cannot be done via the post-evaluation Go template
+// substitution because that operates on JSON byte streams (string values
+// only).
+func newJsonnetVM() *jsonnet.VM {
+	vm := jsonnet.MakeVM()
+	vm.NativeFunction(&jsonnet.NativeFunction{
+		Name:   "must_env",
+		Params: []ast.Identifier{"name"},
+		Func: func(args []interface{}) (interface{}, error) {
+			key, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("must_env: name must be a string")
+			}
+			v, ok := os.LookupEnv(key)
+			if !ok {
+				return nil, fmt.Errorf("must_env: environment variable %q is not set", key)
+			}
+			return v, nil
+		},
+	})
+	vm.NativeFunction(&jsonnet.NativeFunction{
+		Name:   "env",
+		Params: []ast.Identifier{"name", "default"},
+		Func: func(args []interface{}) (interface{}, error) {
+			key, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("env: name must be a string")
+			}
+			if v, ok := os.LookupEnv(key); ok {
+				return v, nil
+			}
+			return args[1], nil
+		},
+	})
+	return vm
+}

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -1,0 +1,69 @@
+package ecschedule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestJsonnetMustEnv(t *testing.T) {
+	t.Setenv("ECSCHEDULE_TEST_ENV", "prod")
+	vm := newJsonnetVM()
+	out, err := vm.EvaluateAnonymousSnippet("test.jsonnet", `{
+      v: std.native('must_env')('ECSCHEDULE_TEST_ENV'),
+      isProd: std.native('must_env')('ECSCHEDULE_TEST_ENV') == 'prod',
+    }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"v": "prod"`) {
+		t.Errorf("expected v=prod, got %s", out)
+	}
+	if !strings.Contains(out, `"isProd": true`) {
+		t.Errorf("expected isProd=true, got %s", out)
+	}
+}
+
+func TestJsonnetMustEnvUnset(t *testing.T) {
+	vm := newJsonnetVM()
+	_, err := vm.EvaluateAnonymousSnippet("test.jsonnet",
+		`std.native('must_env')('ECSCHEDULE_TEST_UNSET_VAR_XYZ')`)
+	if err == nil {
+		t.Error("expected error for unset env var, got nil")
+	}
+}
+
+func TestJsonnetEnv(t *testing.T) {
+	t.Setenv("ECSCHEDULE_TEST_ENV", "production")
+	vm := newJsonnetVM()
+	out, err := vm.EvaluateAnonymousSnippet("test.jsonnet", `{
+      set: std.native('env')('ECSCHEDULE_TEST_ENV', 'default'),
+      unset: std.native('env')('ECSCHEDULE_TEST_UNSET_VAR_XYZ', 'default'),
+    }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"set": "production"`) {
+		t.Errorf("expected set=production, got %s", out)
+	}
+	if !strings.Contains(out, `"unset": "default"`) {
+		t.Errorf("expected unset=default, got %s", out)
+	}
+}
+
+// Regression test for the boolean-field motivation: a non-string field
+// (here, `disabled`) must be set at jsonnet evaluation time. The existing
+// post-evaluation Go template substitution can only modify string values
+// inside JSON, so it can't produce a JSON boolean for `Disabled bool`.
+func TestJsonnetEnvBoolField(t *testing.T) {
+	t.Setenv("ECSCHEDULE_TEST_ENV", "prod")
+	vm := newJsonnetVM()
+	out, err := vm.EvaluateAnonymousSnippet("test.jsonnet", `{
+      disabled: std.native('must_env')('ECSCHEDULE_TEST_ENV') == 'prod',
+    }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"disabled": true`) {
+		t.Errorf("expected disabled=true (boolean), got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Add `must_env` and `env` as Jsonnet native functions when evaluating `.jsonnet` config files. These mirror the Go template helpers in `template.go` so that Jsonnet configs can branch on environment variables *at evaluation time*.

## Motivation

The existing `{{ must_env "ENV" }}` Go template substitution operates on the JSON bytes produced by Jsonnet evaluation. This means it can only substitute values inside string literals — it cannot produce a boolean, number, or any non-string JSON token because Jsonnet always JSON-quotes its output and `json.Unmarshal` cannot coerce a string to a `bool` field.

In practice this is limiting for fields like `Rule.Disabled bool`, which a user would naturally want to set conditionally per environment (e.g., "all rules disabled in prod, enabled in dev"). With the existing template-only mechanism, writing:

```jsonnet
disabled: '{{ if eq (must_env `ENV`) `prod` }}true{{ else }}false{{ end }}'
```

produces `"disabled": "true"` (string) in the JSON, which then fails:

    json: cannot unmarshal string into Go struct field Rule.rules.disabled of type bool

With this PR, the same conditional becomes:

```jsonnet
local isProd = std.native('must_env')('ENV') == 'prod';
{ ..., rules: [{ ..., disabled: isProd }] }
```

which evaluates to a proper JSON boolean at Jsonnet evaluation time and passes through unchanged to `json.Unmarshal`.

## Changes

- Add `jsonnet.go` with a helper `newJsonnetVM()` that registers `must_env(name)` and `env(name, default)` as Jsonnet native functions.
- Wire `newJsonnetVM()` into `readConfigFile` in `config.go`.
- Add `jsonnet_test.go` with unit tests for `must_env`, `env`, the unset-variable error path, and a regression test for the original boolean-field motivation.
- Document the new native functions in `README.md`.

## Compatibility

Existing configs that only use Go template `{{ must_env ... }}` continue to work unchanged — those substitutions happen *after* Jsonnet evaluation on the JSON bytes, and that code path is untouched. The new native functions are only invoked when a config explicitly calls `std.native('must_env')` or `std.native('env')`.