### PR TITLE
feat: support -ext-str and -ext-code flags for jsonnet std.extVar

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,37 @@ Priority: `--no-color` flag > `NO_COLOR` > `ECSCHEDULE_COLOR` > default (colored
 
 **Note**: The `--no-color` flag is a subcommand-level flag and only affects unified diff format. The default pretty format always displays with colors.
 
+### Jsonnet external variables
+
+When the configuration file is a Jsonnet (`*.jsonnet`) file, you can pass values
+to `std.extVar` from the command line using top-level `-ext-str` / `-ext-code`
+flags, mirroring the upstream `jsonnet` CLI:
+
+```console
+% ecschedule -conf ecschedule.jsonnet \
+    -ext-str CLUSTER=api -ext-str REGION=us-east-1 \
+    -ext-code 'TASK_COUNT=2' \
+    apply -all
+```
+
+`-ext-str key=value` binds a string. `-ext-code key=value` binds a Jsonnet
+expression (numbers, arrays, objects, etc.). Either form may also be passed as
+just `-ext-str KEY` / `-ext-code KEY`, in which case the value is read from the
+environment variable of the same name. Both flags may be repeated.
+
+```jsonnet
+{
+  region: std.extVar('REGION'),
+  cluster: std.extVar('CLUSTER'),
+  rules: [
+    {
+      // ...
+      taskCount: std.extVar('TASK_COUNT'),  // -ext-code so it stays a number
+    },
+  ],
+}
+```
+
 ## Functions
 
 You can use following functions in the configuration file.

--- a/cmd_apply.go
+++ b/cmd_apply.go
@@ -50,7 +50,7 @@ var cmdApply = &runnerImpl{
 				return err
 			}
 			defer f.Close()
-			c, err = LoadConfig(ctx, f, a.AccountID, *conf)
+			c, err = LoadConfig(ctx, f, a.AccountID, *conf, a.loadConfigOptions()...)
 			if err != nil {
 				return err
 			}

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -59,7 +59,7 @@ var cmdDiff = &runnerImpl{
 				return err
 			}
 			defer f.Close()
-			c, err = LoadConfig(ctx, f, a.AccountID, *conf)
+			c, err = LoadConfig(ctx, f, a.AccountID, *conf, a.loadConfigOptions()...)
 			if err != nil {
 				return err
 			}

--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -37,7 +37,7 @@ var cmdDump = &runnerImpl{
 				return err
 			}
 			defer f.Close()
-			c, err = LoadConfig(ctx, f, a.AccountID, *conf)
+			c, err = LoadConfig(ctx, f, a.AccountID, *conf, a.loadConfigOptions()...)
 			if err != nil {
 				return err
 			}

--- a/cmd_run.go
+++ b/cmd_run.go
@@ -36,7 +36,7 @@ var cmdRun = &runnerImpl{
 				return err
 			}
 			defer f.Close()
-			c, err = LoadConfig(ctx, f, a.AccountID, *conf)
+			c, err = LoadConfig(ctx, f, a.AccountID, *conf, a.loadConfigOptions()...)
 			if err != nil {
 				return err
 			}

--- a/config.go
+++ b/config.go
@@ -95,10 +95,46 @@ func validateCronExpression(exp string) error {
 	return nil
 }
 
+type loadConfigOptions struct {
+	extStr  map[string]string
+	extCode map[string]string
+}
+
+// LoadConfigOption configures LoadConfig
+type LoadConfigOption func(*loadConfigOptions)
+
+// WithExtStr binds Jsonnet std.extVar string variables
+func WithExtStr(vars map[string]string) LoadConfigOption {
+	return func(o *loadConfigOptions) {
+		if o.extStr == nil {
+			o.extStr = map[string]string{}
+		}
+		for k, v := range vars {
+			o.extStr[k] = v
+		}
+	}
+}
+
+// WithExtCode binds Jsonnet std.extVar code variables
+func WithExtCode(vars map[string]string) LoadConfigOption {
+	return func(o *loadConfigOptions) {
+		if o.extCode == nil {
+			o.extCode = map[string]string{}
+		}
+		for k, v := range vars {
+			o.extCode[k] = v
+		}
+	}
+}
+
 // LoadConfig loads config
-func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath string) (*Config, error) {
+func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath string, opts ...LoadConfigOption) (*Config, error) {
+	var o loadConfigOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	c := Config{}
-	bs, ext, err := readConfigFile(r, confPath)
+	bs, ext, err := readConfigFile(r, confPath, &o)
 	if err != nil {
 		return nil, err
 	}
@@ -152,10 +188,16 @@ func unmarshalConfig(bs []byte, c *Config, ext string) error {
 	return yaml.Unmarshal(bs, c)
 }
 
-func readConfigFile(r io.Reader, confPath string) ([]byte, string, error) {
+func readConfigFile(r io.Reader, confPath string, o *loadConfigOptions) ([]byte, string, error) {
 	ext := filepath.Ext(confPath)
 	if ext == jsonnetExt {
 		vm := newJsonnetVM()
+		for k, v := range o.extStr {
+			vm.ExtVar(k, v)
+		}
+		for k, v := range o.extCode {
+			vm.ExtCode(k, v)
+		}
 		bs, err := vm.EvaluateFile(confPath)
 		if err != nil {
 			return nil, ext, fmt.Errorf("failed to evaluate jsonnet file: %w", err)

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package ecschedule
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"text/template"
@@ -88,7 +89,19 @@ func TestLoadConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer f.Close()
-		c, err := LoadConfig(context.Background(), f, "334", path)
+		var opts []LoadConfigOption
+		if filepath.Ext(path) == jsonnetExt {
+			opts = append(opts,
+				WithExtStr(map[string]string{
+					"REGION":  "us-east-1",
+					"CLUSTER": "api",
+				}),
+				WithExtCode(map[string]string{
+					"BASE": "1",
+				}),
+			)
+		}
+		c, err := LoadConfig(context.Background(), f, "334", path, opts...)
 		if err != nil {
 			t.Errorf("error should be nil, but: %s", err)
 		}
@@ -202,6 +215,21 @@ func TestLoadConfig_tfstate_multi(t *testing.T) {
 	esg := []string{"sg-11111111", "sg-99999999"}
 	if !reflect.DeepEqual(asg, esg) {
 		t.Errorf("error should be %v, but: %v", asg, esg)
+	}
+}
+
+func TestLoadConfig_jsonnetExtVar_missing(t *testing.T) {
+	// std.extVar references in sample.jsonnet must be supplied; otherwise
+	// jsonnet should error rather than silently substituting an empty value.
+	path := "testdata/sample.jsonnet"
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if _, err := LoadConfig(context.Background(), f, "334", path); err == nil {
+		t.Error("expected error when std.extVar bindings are missing, got nil")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -218,6 +218,27 @@ func TestLoadConfig_tfstate_multi(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_tfstate_multi_jsonnet(t *testing.T) {
+	path := "testdata/sample5.jsonnet"
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	c, err := LoadConfig(context.Background(), f, "338", path)
+	if err != nil {
+		t.Fatalf("error should be nil, but: %s", err)
+	}
+
+	if !reflect.DeepEqual(c.Plugins, []*Plugin{
+		{Name: "tfstate", Config: map[string]interface{}{"path": "testdata/terraform.tfstate"}, FuncPrefix: "first_"},
+		{Name: "tfstate", Config: map[string]interface{}{"path": "testdata/terraform.tfstate"}, FuncPrefix: "second_"},
+	}) {
+		t.Errorf("unexpected output: %#v", c.Plugins)
+	}
+}
+
 func TestLoadConfig_jsonnetExtVar_missing(t *testing.T) {
 	// std.extVar references in sample.jsonnet must be supplied; otherwise
 	// jsonnet should error rather than silently substituting an empty value.

--- a/context.go
+++ b/context.go
@@ -14,6 +14,19 @@ type app struct {
 	Config    *Config
 	AccountID string
 	AwsConf   aws.Config
+	ExtStr    map[string]string
+	ExtCode   map[string]string
+}
+
+func (a *app) loadConfigOptions() []LoadConfigOption {
+	var opts []LoadConfigOption
+	if len(a.ExtStr) > 0 {
+		opts = append(opts, WithExtStr(a.ExtStr))
+	}
+	if len(a.ExtCode) > 0 {
+		opts = append(opts, WithExtCode(a.ExtCode))
+	}
+	return opts
 }
 
 func setApp(ctx context.Context, a *app) context.Context {

--- a/ecsched.go
+++ b/ecsched.go
@@ -7,11 +7,49 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 
 const cmdName = "ecschedule"
+
+// extVarFlag accumulates repeated -ext-str/-ext-code key=value (or bare key, read from env) pairs
+type extVarFlag struct {
+	pairs map[string]string
+}
+
+func newExtVarFlag() *extVarFlag {
+	return &extVarFlag{pairs: map[string]string{}}
+}
+
+func (e *extVarFlag) String() string {
+	parts := make([]string, 0, len(e.pairs))
+	for k, v := range e.pairs {
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (e *extVarFlag) Set(s string) error {
+	if i := strings.IndexByte(s, '='); i >= 0 {
+		key := s[:i]
+		if key == "" {
+			return fmt.Errorf("empty key in %q", s)
+		}
+		e.pairs[key] = s[i+1:]
+		return nil
+	}
+	if s == "" {
+		return fmt.Errorf("empty key")
+	}
+	v, ok := os.LookupEnv(s)
+	if !ok {
+		return fmt.Errorf("environment variable %q is not defined", s)
+	}
+	e.pairs[s] = v
+	return nil
+}
 
 // Run the ecschedule
 func Run(ctx context.Context, argv []string, outStream, errStream io.Writer) error {
@@ -28,9 +66,13 @@ func Run(ctx context.Context, argv []string, outStream, errStream io.Writer) err
 		formatCommands(fs.Output())
 	}
 	var (
-		conf = fs.String("conf", "", "configuration")
-		ver  = fs.Bool("version", false, "display version")
+		conf    = fs.String("conf", "", "configuration")
+		ver     = fs.Bool("version", false, "display version")
+		extStr  = newExtVarFlag()
+		extCode = newExtVarFlag()
 	)
+	fs.Var(extStr, "ext-str", "jsonnet std.extVar string binding (key=value, or just key to read from env)")
+	fs.Var(extCode, "ext-code", "jsonnet std.extVar code binding (key=value, or just key to read from env)")
 	if err := fs.Parse(argv); err != nil {
 		return err
 	}
@@ -48,6 +90,8 @@ func Run(ctx context.Context, argv []string, outStream, errStream io.Writer) err
 	a := &app{
 		AccountID: accountID,
 		AwsConf:   awsConf,
+		ExtStr:    extStr.pairs,
+		ExtCode:   extCode.pairs,
 	}
 	ctx = setApp(ctx, a)
 	if *conf != "" {
@@ -56,7 +100,7 @@ func Run(ctx context.Context, argv []string, outStream, errStream io.Writer) err
 			return err
 		}
 		defer f.Close()
-		c, err := LoadConfig(ctx, f, a.AccountID, *conf)
+		c, err := LoadConfig(ctx, f, a.AccountID, *conf, a.loadConfigOptions()...)
 		if err != nil {
 			return err
 		}

--- a/plugin.go
+++ b/plugin.go
@@ -14,9 +14,9 @@ import (
 
 // Plugin the plugin
 type Plugin struct {
-	Name       string                 `yaml:"name"`
-	Config     map[string]interface{} `yaml:"config"`
-	FuncPrefix string                 `yaml:"func_prefix,omitempty"`
+	Name       string                 `yaml:"name" json:"name"`
+	Config     map[string]interface{} `yaml:"config" json:"config"`
+	FuncPrefix string                 `yaml:"func_prefix,omitempty" json:"func_prefix,omitempty"`
 }
 
 func (p Plugin) setup(ctx context.Context, c *Config) error {

--- a/testdata/sample.jsonnet
+++ b/testdata/sample.jsonnet
@@ -1,8 +1,8 @@
 local envs = import 'envs.libsonnet';
 
 {
-  "region": "us-east-1",
-  "cluster": "api",
+  "region": std.extVar('REGION'),
+  "cluster": std.extVar('CLUSTER'),
   "role": "ecsEventsRole",
   "rules": [
     {
@@ -16,7 +16,7 @@ local envs = import 'envs.libsonnet';
       "capacityProviderStrategy": [
         {
           "capacityProvider": "FARGATE",
-          "base": 1,
+          "base": std.extVar('BASE'),
           "weight": 1
         }
       ],

--- a/testdata/sample5.jsonnet
+++ b/testdata/sample5.jsonnet
@@ -1,0 +1,58 @@
+{
+  "region": "us-east-1",
+  "cluster": "api",
+  "role": "ecsEventsRole",
+  "rules": [
+    {
+      "name": "hoge-task-name",
+      "description": "hoge description",
+      "scheduleExpression": "cron(0 0 * * ? *)",
+      "taskDefinition": "task1",
+      "group": "xxx",
+      "platform_version": "1.4.0",
+      "launch_type": "FARGATE",
+      "network_configuration": {
+        "aws_vpc_configuration": {
+          "subnets": [
+            "{{ plugin `first_tfstate` `aws_subnet.private-a.id` }}",
+            "{{ plugin `second_tfstate` `aws_subnet.private-c.id` }}",
+          ],
+          "security_groups": [
+            "{{ plugin `first_tfstatef` `data.aws_security_group.default['%s'].id` `first` }}",
+            "{{ plugin `second_tfstatef` `data.aws_security_group.default['%s'].id` `second` }}",
+          ],
+          "assign_public_ip": "ENABLED",
+        },
+      },
+      "containerOverrides": [
+        {
+          "name": "container1",
+          "command": ["subcmd", "argument"],
+          "environment": {
+            "HOGE_ENV": "{{ env `DUMMY_HOGE_ENV` `HOGEGE` }}",
+          },
+        },
+      ],
+      "dead_letter_config": {
+        "sqs": "queue1",
+      },
+      "propagateTags": "TASK_DEFINITION",
+    },
+  ],
+  "plugins": [
+    {
+      "name": "tfstate",
+      "config": {
+        "path": "testdata/terraform.tfstate",
+      },
+      "func_prefix": "first_",
+    },
+    {
+      "name": "tfstate",
+      "config": {
+        "path": "testdata/terraform.tfstate",
+      },
+      "func_prefix": "second_",
+    },
+  ],
+}


### PR DESCRIPTION
# Summary

This PR adds top-level `-ext-str` and `-ext-code` flags that bind values to `str.extVar()` references then the configuration filer is a Jsonnet file. There flags are mirroring the upstream jsonnet CLI. Also fixes the Plugin struct so plugins declared in Jsonnet configs are decoded correctly.



# Background

Until now, Jsonnet configurations could only be evaluated with values hard-coded in the file (or imported via libsonnet). There was no way to inject values from the CLI or the environment at evaluation time, which made it awkward to share a single Jsonnet template across environments (e.g. region, cluster name, task counts).

The upstream jsonnet CLI exposes --ext-str / --ext-code for exactly this purpose, and ecschedule users expect the same ergonomics when running ecschedule apply / diff / dump / run.

Separately, the Plugin struct only had yaml tags. When a Jsonnet config went through the Jsonnet → JSON → YAML path, the plugins block decoded into empty Plugin values, so plugins declared in Jsonnet did not work.

# Changes

- CLI: Add repeatable -ext-str and -ext-code flags on the top-level command.
  - -ext-str KEY=VALUE binds a string; -ext-code KEY=VALUE binds a Jsonnet expression (numbers, arrays, objects, …).
  - Bare -ext-str KEY / -ext-code KEY reads the value from the environment variable of the same name and errors if it is not defined.
- Library API: Extend LoadConfig with functional options WithExtStr(map[string]string) and WithExtCode(map[string]string). These are
  forwarded to jsonnet.VM.ExtVar / ExtCode when the config file has a .jsonnet extension.
- Plugin decoding: Add json tags to Plugin (name, config, func_prefix) so plugins declared in Jsonnet configs decode correctly.
