### PR TITLE
Support -parallel > 1 for real apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Notes for parallel apply (`-parallel > 1`):
 
 ### Signal Handling
 
-Since the introduction of parallel apply, all subcommands handle SIGINT/SIGTERM gracefully: the first signal cancels in-progress work at API-call boundaries (for parallel apply, no new rules start and in-flight rules finish within the per-rule timeout) and the command exits through the normal error path (exit status 1 with a `💢` message) instead of dying to the signal (previously exit status ~130). A second signal restores default fatal handling and kills the process immediately.
+Since the introduction of parallel apply, all subcommands handle SIGINT/SIGTERM gracefully. The first signal stops work at API-call boundaries and the command exits through the normal error path (exit status 1 with a `💢` message) instead of dying to the signal (previously exit status ~130). A second signal restores default fatal handling and kills the process immediately.
+
+One part is deliberately exempt from that first signal: a rule whose write has already begun always completes its `PutRule` → `PutTargets` → `TagResource` sequence. That sequence is detached from the signal (it runs under `context.WithoutCancel`) and bounded only by the per-rule timeout, so no rule is ever left half-written. This holds for any real `apply`, with or without `-parallel`. What the first signal does stop in a parallel apply is admission: no further rules start, and the command waits for the in-flight ones.
 
 ## Log Format
 
@@ -210,7 +212,7 @@ ecschedule supports unified diff format (similar to `git diff`) with `-u` flag f
 ```
 
 The `diff` command with `-u` flag outputs pure diff content without log prefixes or headers, making it suitable for piping to other tools.
-The `apply` command includes progress logs even with `-u` flag (with `-parallel > 1`, output is grouped into one block per rule).
+The `apply` command includes progress logs even with `-u` flag. With `-parallel > 1`, each rule's *result* — the diff and the resulting YAML — is written as a single indivisible block, so it never interleaves with another rule's result. The short `applying rule "..."` progress lines are emitted as each rule starts, so those do appear between result blocks.
 
 ### Color control
 

--- a/README.md
+++ b/README.md
@@ -166,17 +166,37 @@ This performs the same validation as `apply` and `run`, with a slight overhead, 
 
 ### Parallel Execution
 
-The `diff` command and `apply -dry-run` support parallel execution for improved performance with many rules:
+The `diff` and `apply` commands support parallel execution for improved performance with many rules:
 
 ```console
 % ecschedule -conf ecschedule.yaml diff -all -parallel 10
 % ecschedule -conf ecschedule.yaml apply -all -dry-run -parallel 10
+% ecschedule -conf ecschedule.yaml apply -all -parallel 10
 ```
 
 - Default: `parallel=1` (sequential, backward compatible)
-- Recommended: 1-10 (due to AWS API rate limits)
+- Recommended: 1-10 (due to AWS API rate limits; quotas are per-account per-region and adjustable via Service Quotas — large rule sets should expect throttling-driven retries)
 - Note: Output order is not guaranteed when parallel > 1
-- Note: `-parallel` is only effective with `-dry-run` for the `apply` command. Using it without `-dry-run` returns an error.
+
+For real `apply`, the failure semantics depend on `-parallel`:
+
+| | behavior on a rule failure |
+|---|---|
+| `-parallel 1` (default) | stops at the first error (unchanged) |
+| `-parallel N` (N > 1) | all rules are validated **before any write**; every changed rule is then attempted; failures are aggregated into an end-of-run summary and the exit status is non-zero |
+
+Notes for parallel apply (`-parallel > 1`):
+
+- A rule that has started writing always completes its `PutRule` → `PutTargets` → `TagResource` sequence (bounded by a 2-minute per-rule timeout). The first Ctrl-C stops starting new rules and waits for in-flight ones; a second Ctrl-C force-quits. In CI, make sure the cancellation grace period exceeds the per-rule timeout or a hard kill may still interrupt a write.
+- Re-running `apply` after a partial failure converges, with two exceptions: changing a `targetId` leaves the old target attached remotely (the rule fires both targets and subsequently diffs as a new rule), and a rule whose tagging (`TagResource`) failed is NOT healed by re-run — the failure message prints the exact `aws events tag-resource` command to repair it.
+- If every rule retries for ~2 minutes and then fails with `LimitExceededException`, you hit the rules-per-bus quota — raise it via Service Quotas instead of waiting out retries.
+- Rule names must be unique: configurations containing duplicate rule names are rejected at load time (for every subcommand).
+- `-prune` orphan detection only searches the region of your ambient AWS configuration; rules in per-rule `region` overrides are outside its view.
+- With `-parallel > 1` the SDK retry budget is shared per region (not per rule), so under sustained failures some rules may fail fast with a rate-limit-token error instead of the underlying one — two error texts can appear for a single root cause.
+
+### Signal Handling
+
+Since the introduction of parallel apply, all subcommands handle SIGINT/SIGTERM gracefully: the first signal cancels in-progress work at API-call boundaries (for parallel apply, no new rules start and in-flight rules finish within the per-rule timeout) and the command exits through the normal error path (exit status 1 with a `💢` message) instead of dying to the signal (previously exit status ~130). A second signal restores default fatal handling and kills the process immediately.
 
 ## Log Format
 
@@ -190,7 +210,7 @@ ecschedule supports unified diff format (similar to `git diff`) with `-u` flag f
 ```
 
 The `diff` command with `-u` flag outputs pure diff content without log prefixes or headers, making it suitable for piping to other tools.
-The `apply` command includes progress logs even with `-u` flag.
+The `apply` command includes progress logs even with `-u` flag (with `-parallel > 1`, output is grouped into one block per rule).
 
 ### Color control
 

--- a/cmd/ecschedule/main.go
+++ b/cmd/ecschedule/main.go
@@ -5,13 +5,24 @@ import (
 	"flag"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/Songmu/ecschedule"
 )
 
 func main() {
 	log.SetFlags(0)
-	err := ecschedule.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	// After the first signal cancels ctx, unregister so a second
+	// SIGINT/SIGTERM gets default (fatal) handling — the escape hatch
+	// when an in-flight AWS call refuses to finish.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+	err := ecschedule.Run(ctx, os.Args[1:], os.Stdout, os.Stderr)
 	if err != nil && err != flag.ErrHelp {
 		log.Printf("💢 %s\n", err)
 		exitCode := 1

--- a/cmd_apply.go
+++ b/cmd_apply.go
@@ -31,7 +31,7 @@ var cmdApply = &runnerImpl{
 			prune    = fs.Bool("prune", false, "prune orphaned rules after apply")
 			unified  = fs.Bool("u", false, "output diff in unified format (colored, similar to git diff)")
 			noColor  = fs.Bool("no-color", false, "disable colored output (Unified diff format only)")
-			parallel = fs.Int("parallel", 1, "number of parallel workers for dry-run (default: 1, only effective with -dry-run, recommended: 1-10 due to AWS API rate limits. Note: output order is not guaranteed when parallel > 1)")
+			parallel = fs.Int("parallel", 1, "number of parallel workers (default: 1, recommended: 1-10 due to AWS API rate limits. Note: output order is not guaranteed when parallel > 1)")
 		)
 		if err := fs.Parse(argv); err != nil {
 			return err
@@ -41,6 +41,9 @@ var cmdApply = &runnerImpl{
 
 		if !*all && *rule == "" {
 			return errors.New("-rule or -all option required")
+		}
+		if *parallel < 1 {
+			return errors.New("-parallel must be at least 1")
 		}
 		a := getApp(ctx)
 		c := a.Config
@@ -66,13 +69,6 @@ var cmdApply = &runnerImpl{
 			for _, r := range c.Rules {
 				ruleNames = append(ruleNames, r.Name)
 			}
-		}
-
-		if *parallel < 1 {
-			return errors.New("-parallel must be at least 1")
-		}
-		if *parallel > 1 && !*dryRun {
-			return errors.New("-parallel can only be used with -dry-run (apply parallelization is not yet supported)")
 		}
 
 		var dryRunSuffix string
@@ -104,6 +100,10 @@ var cmdApply = &runnerImpl{
 				log.Printf("✅ following rule applied%s\n%s", dryRunSuffix, result.ruleYaml)
 			}
 			if err := <-errChan; err != nil {
+				return err
+			}
+		} else if *parallel > 1 {
+			if err := runParallelApply(ctx, a.AwsConf, c, ruleNames, *parallel, format); err != nil {
 				return err
 			}
 		} else {

--- a/cmd_apply.go
+++ b/cmd_apply.go
@@ -79,13 +79,16 @@ var cmdApply = &runnerImpl{
 		format := selectDiffFormat(*unified)
 
 		if *dryRun {
+			// Shared across workers so rules pointing at the same task
+			// definition describe it once instead of once per rule.
+			tdv := newTaskDefValidator()
 			processApplyDryRunJob := func(ctx context.Context, ruleName string) (applyDryRunResult, error) {
 				ru := c.GetRuleByName(ruleName)
 				if ru == nil {
 					return applyDryRunResult{}, fmt.Errorf("no rules found for %s", ruleName)
 				}
 				log.Printf("applying the rule %q%s", ruleName, dryRunSuffix)
-				if err := ru.applyInternal(ctx, a.AwsConf, true, format); err != nil {
+				if err := ru.applyInternalWith(ctx, a.AwsConf, true, format, tdv); err != nil {
 					return applyDryRunResult{}, err
 				}
 				for _, v := range ru.ContainerOverrides {

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -86,6 +86,10 @@ var cmdDiff = &runnerImpl{
 
 		var hasValidationError atomic.Bool
 
+		// Shared across workers so rules pointing at the same task
+		// definition describe it once instead of once per rule.
+		tdv := newTaskDefValidator()
+
 		processDiffJob := func(ctx context.Context, ruleName string) (diffResult, error) {
 			result := diffResult{ruleName: ruleName}
 
@@ -104,7 +108,7 @@ var cmdDiff = &runnerImpl{
 				if err := ru.validateSSM(); err != nil {
 					result.validationErrors = append(result.validationErrors, fmt.Sprintf("  ssm: %s", err))
 				}
-				if err := ru.validateTaskDefinition(ctx, a.AwsConf); err != nil {
+				if err := tdv.validate(ctx, ru, a.AwsConf); err != nil {
 					result.validationErrors = append(result.validationErrors, fmt.Sprintf("  task definition: %s", err))
 				}
 

--- a/config.go
+++ b/config.go
@@ -75,6 +75,29 @@ func (c *Config) cronValidate() error {
 	return nil
 }
 
+// validateUniqueRuleNames rejects configurations containing multiple rules
+// with the same name. GetRuleByName resolves names to the first match, so
+// duplicates silently shadow each other and, worse, hand the same *Rule to
+// multiple parallel workers (a data race).
+func (c *Config) validateUniqueRuleNames() error {
+	seen := map[string]bool{}
+	reported := map[string]bool{}
+	var dups []string
+	for _, r := range c.Rules {
+		if seen[r.Name] && !reported[r.Name] {
+			dups = append(dups, r.Name)
+			reported[r.Name] = true
+		}
+		seen[r.Name] = true
+	}
+	if len(dups) > 0 {
+		return fmt.Errorf(
+			"duplicate rule name(s) in configuration: %s (rule names must be unique; regenerate a clean config with `ecschedule dump -region <region> -cluster <cluster>`)",
+			strings.Join(dups, ", "))
+	}
+	return nil
+}
+
 func validateCronExpression(exp string) error {
 	if strings.HasPrefix(exp, "rate(") && strings.HasSuffix(exp, ")") {
 		return nil
@@ -174,6 +197,9 @@ func LoadConfig(ctx context.Context, r io.Reader, accountID string, confPath str
 	}
 	for _, r := range c.Rules {
 		r.mergeBaseConfig(c.BaseConfig, c.Role)
+	}
+	if err := c.validateUniqueRuleNames(); err != nil {
+		return nil, err
 	}
 	return &c, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -277,5 +278,38 @@ func TestCronValidate(t *testing.T) {
 		"\trule \"rule-5\": trailing or leading spaces are not allowed inside parentheses: \"cron( 0 0 * * ? * )\""
 	if g := err.Error(); g != e {
 		t.Errorf("unexpected error message\nwant:\n%s\n\ngot:\n%s", e, g)
+	}
+}
+
+func TestLoadConfigDuplicateRuleNames(t *testing.T) {
+	conf := `region: us-east-1
+cluster: api
+rules:
+- name: dup-task
+  scheduleExpression: cron(0 0 * * ? *)
+  taskDefinition: task1
+- name: dup-task
+  scheduleExpression: cron(5 0 * * ? *)
+  taskDefinition: task2
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dup.yaml")
+	if err := os.WriteFile(path, []byte(conf), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, err = LoadConfig(context.Background(), f, "334", path)
+	if err == nil {
+		t.Fatal("expected duplicate rule name error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dup-task") {
+		t.Errorf("error should name the duplicate rule, got: %s", err)
+	}
+	if !strings.Contains(err.Error(), "ecschedule dump") {
+		t.Errorf("error should mention the dump escape hatch, got: %s", err)
 	}
 }

--- a/parallel.go
+++ b/parallel.go
@@ -10,6 +10,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// executeJobsInParallel is the original fail-fast runner: all jobs share
+// one errgroup.WithContext, so the first error cancels the context and the
+// rest stop early. diff and apply -dry-run still use it.
+//
+// New callers should prefer executeJobsInParallelContinueOnError, the more
+// general of the two: fail-fast can be layered on top of it by cancelling
+// a derived context when the first error arrives, while the reverse is not
+// possible. Moving the remaining callers over would change what they
+// report — every rule's error instead of only the first — so that is left
+// out of this change. The intent is to consolidate on that runner and drop
+// this function once the behavior change is acceptable.
 func executeJobsInParallel[T any](
 	ctx context.Context,
 	ruleNames []string,
@@ -64,4 +75,69 @@ func executeJobsInParallel[T any](
 	}()
 
 	return results, errChan
+}
+
+// jobOutcome is the result of one named job run by
+// executeJobsInParallelContinueOnError.
+type jobOutcome[T any] struct {
+	Index   int // position in names; summaries sort by this
+	Name    string
+	Result  T
+	Err     error
+	Skipped bool // admission saw a canceled ctx; jobFunc never ran
+}
+
+// executeJobsInParallelContinueOnError runs jobFunc for every name with
+// at most `parallel` workers and returns a channel of outcomes in
+// completion order.
+//
+// Contract:
+//   - The channel is buffered to len(names); sends never block.
+//   - Submission, g.Wait(), and close all run in one background goroutine;
+//     the function returns the channel immediately, so callers can consume
+//     outcomes while jobs are still being admitted.
+//   - One job's failure never cancels sibling jobs (plain errgroup.Group,
+//     errors are recorded in the outcome, never returned to the group).
+//   - Every name yields exactly one outcome on every path — success,
+//     error, admission skip, panic — via a single deferred send. The
+//     submission loop never breaks early, so Index coverage is total.
+//   - Each job checks ctx at admission; if already canceled it emits
+//     Skipped without running jobFunc. Jobs are admitted in names order
+//     (g.Go blocks while saturated, blocking the background goroutine).
+//   - A panic in jobFunc is recovered and recorded as that job's error,
+//     with the stack embedded.
+func executeJobsInParallelContinueOnError[T any](
+	ctx context.Context,
+	names []string,
+	parallel int,
+	jobFunc func(ctx context.Context, name string) (T, error),
+) <-chan jobOutcome[T] {
+	outcomes := make(chan jobOutcome[T], len(names))
+	var g errgroup.Group
+	g.SetLimit(parallel)
+
+	go func() {
+		for i, name := range names {
+			g.Go(func() error {
+				out := jobOutcome[T]{Index: i, Name: name}
+				defer func() {
+					if rec := recover(); rec != nil {
+						out.Err = fmt.Errorf("panic in worker for rule %q: %v\n%s",
+							name, rec, debug.Stack())
+					}
+					outcomes <- out
+				}()
+				if ctx.Err() != nil {
+					out.Skipped = true
+					return nil
+				}
+				out.Result, out.Err = jobFunc(ctx, name)
+				return nil
+			})
+		}
+		_ = g.Wait()
+		close(outcomes)
+	}()
+
+	return outcomes
 }

--- a/parallel_apply.go
+++ b/parallel_apply.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/goccy/go-yaml"
 )
 
@@ -50,13 +51,21 @@ func runParallelApply(ctx context.Context, awsConf aws.Config, c *Config, ruleNa
 	// error lists every failure and blocks all writes. Interruption is
 	// classified separately so Ctrl-C doesn't masquerade as a wall of
 	// validation errors.
+	//
+	// The validator memoizes DescribeTaskDefinition across rules and gets
+	// the same raised retry budget as the EventBridge clients: planning is
+	// where the call volume peaks, so it is the phase most exposed to
+	// throttling.
+	tdv := newTaskDefValidator(func(o *ecs.Options) {
+		o.RetryMaxAttempts = parallelRetryMaxAttempts
+	})
 	plans := make(map[string]*applyPlan, len(ruleNames))
 	var planErrs []jobOutcome[*applyPlan]
 	interrupted := false
 	for out := range executeJobsInParallelContinueOnError(ctx, ruleNames, parallel,
 		func(ctx context.Context, name string) (*applyPlan, error) {
 			ru := rules[name]
-			return ru.plan(ctx, awsConf, clients[ru.Region], format)
+			return ru.plan(ctx, awsConf, clients[ru.Region], format, tdv)
 		}) {
 		switch {
 		case out.Skipped || (out.Err != nil && errors.Is(out.Err, context.Canceled)):

--- a/parallel_apply.go
+++ b/parallel_apply.go
@@ -1,0 +1,175 @@
+package ecschedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
+	"github.com/goccy/go-yaml"
+)
+
+// parallelRetryMaxAttempts raises the SDK retry budget for the clients
+// built by runParallelApply only: at parallel > 1, EventBridge write
+// throttling is the expected steady state for large rule sets and the
+// default 3 attempts exhaust quickly. The sequential path keeps SDK
+// defaults.
+const parallelRetryMaxAttempts = 10
+
+// runParallelApply is the three-phase apply path used for real apply
+// with -parallel > 1: plan every rule (read-only), execute only the
+// changed ones (continue-on-error), then print a summary.
+//
+// It returns nil ONLY when every rule succeeded (applied or no change)
+// and the run was not interrupted — callers use this as the -prune gate.
+func runParallelApply(ctx context.Context, awsConf aws.Config, c *Config, ruleNames []string, parallel int, format diffFormat) error {
+	// Resolve rules and build one client per region, eagerly: the region
+	// set is known up front, so the map is read-only once workers start.
+	rules := make(map[string]*Rule, len(ruleNames))
+	clients := map[string]*cloudwatchevents.Client{}
+	for _, name := range ruleNames {
+		ru := c.GetRuleByName(name)
+		if ru == nil {
+			return fmt.Errorf("no rules found for %s", name)
+		}
+		rules[name] = ru
+		region := ru.Region
+		if _, ok := clients[region]; !ok {
+			clients[region] = cloudwatchevents.NewFromConfig(awsConf, func(o *cloudwatchevents.Options) {
+				o.Region = region
+				o.RetryMaxAttempts = parallelRetryMaxAttempts
+			})
+		}
+	}
+
+	// Phase 1: plan (read-only). All rules are always planned; a real
+	// error lists every failure and blocks all writes. Interruption is
+	// classified separately so Ctrl-C doesn't masquerade as a wall of
+	// validation errors.
+	plans := make(map[string]*applyPlan, len(ruleNames))
+	var planErrs []jobOutcome[*applyPlan]
+	interrupted := false
+	for out := range executeJobsInParallelContinueOnError(ctx, ruleNames, parallel,
+		func(ctx context.Context, name string) (*applyPlan, error) {
+			ru := rules[name]
+			return ru.plan(ctx, awsConf, clients[ru.Region], format)
+		}) {
+		switch {
+		case out.Skipped || (out.Err != nil && errors.Is(out.Err, context.Canceled)):
+			interrupted = true
+		case out.Err != nil:
+			planErrs = append(planErrs, out)
+		default:
+			plans[out.Name] = out.Result
+		}
+	}
+	if len(planErrs) > 0 {
+		sort.Slice(planErrs, func(i, j int) bool { return planErrs[i].Index < planErrs[j].Index })
+		for _, out := range planErrs {
+			log.Printf("❌ rule %q: %s", out.Name, out.Err)
+		}
+		return fmt.Errorf("%d rule(s) failed validation/planning; no writes were performed", len(planErrs))
+	}
+	if interrupted {
+		log.Println("interrupted during planning; no writes were performed")
+		return errors.New("interrupted: planning canceled")
+	}
+
+	// Classify: no-change rules are reported and excluded from Phase 2.
+	var toApply []string
+	noChange := 0
+	for _, name := range ruleNames {
+		if plans[name].hasChange {
+			toApply = append(toApply, name)
+		} else {
+			log.Printf("💡 rule %q: skip applying. no differences", name)
+			noChange++
+		}
+	}
+
+	// Phase 2: execute (writes). Started rules always finish (execute
+	// shields the write sequence internally); on the first signal only
+	// admission stops.
+	stopNotice := context.AfterFunc(ctx, func() {
+		log.Printf("⚠️ interrupted: waiting for in-flight rule(s) to finish (max %s); press Ctrl-C again to force quit", perRuleApplyTimeout)
+	})
+	defer stopNotice()
+
+	applied := 0
+	var failed []jobOutcome[string]
+	var notStartedOut []jobOutcome[string]
+	for out := range executeJobsInParallelContinueOnError(ctx, toApply, parallel,
+		func(ctx context.Context, name string) (string, error) {
+			ru := rules[name]
+			log.Printf("applying rule %q", name)
+			if err := ru.execute(ctx, clients[ru.Region]); err != nil {
+				return "", err
+			}
+			// Display-time mutation: strictly after this rule's writes.
+			for _, v := range ru.ContainerOverrides {
+				v.Environment = nil
+			}
+			bs, _ := yaml.Marshal(ru)
+			return string(bs), nil
+		}) {
+		switch {
+		case out.Skipped:
+			notStartedOut = append(notStartedOut, out)
+		case out.Err != nil:
+			var tagErr *tagResourceError
+			if errors.As(out.Err, &tagErr) {
+				log.Printf("❌ rule %q: %s\n"+
+					"⚠️ the rule was applied but tagging failed: a rule created by this run is left without the \"ecschedule:tracking-id\" tag and escapes -prune orphan detection (an already-tagged rule keeps its previous tag). Re-running apply will NOT retry the tag. Repair manually:\n"+
+					"  aws events tag-resource --resource-arn %s --tags Key=ecschedule:tracking-id,Value=%s",
+					out.Name, out.Err, tagErr.ruleARN, tagErr.trackingID)
+			} else {
+				log.Printf("❌ rule %q: %s", out.Name, out.Err)
+			}
+			failed = append(failed, out)
+		default:
+			log.Printf("✅ rule %q applied\n💡 applied changes:\n%s%s",
+				out.Name, strings.TrimRight(plans[out.Name].diffOutput, "\n")+"\n", out.Result)
+			applied++
+		}
+	}
+
+	// Phase 3: summary. Lists are deterministic (config order via Index).
+	sort.Slice(failed, func(i, j int) bool { return failed[i].Index < failed[j].Index })
+	sort.Slice(notStartedOut, func(i, j int) bool { return notStartedOut[i].Index < notStartedOut[j].Index })
+	notStarted := make([]string, 0, len(notStartedOut))
+	for _, out := range notStartedOut {
+		notStarted = append(notStarted, out.Name)
+	}
+	log.Print(formatApplySummary(applied, noChange, failed, notStarted))
+
+	if len(failed) > 0 {
+		return fmt.Errorf("%d rule(s) failed", len(failed))
+	}
+	if len(notStarted) > 0 {
+		return fmt.Errorf("interrupted: %d rule(s) not started", len(notStarted))
+	}
+	if ctx.Err() != nil {
+		return errors.New("interrupted")
+	}
+	return nil
+}
+
+func formatApplySummary(applied, noChange int, failed []jobOutcome[string], notStarted []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "apply summary: %d applied, %d no change, %d failed, %d not started",
+		applied, noChange, len(failed), len(notStarted))
+	if len(failed) > 0 {
+		b.WriteString("\nfailed:")
+		for _, f := range failed {
+			fmt.Fprintf(&b, "\n  - %s: %s", f.Name, f.Err)
+		}
+	}
+	if len(notStarted) > 0 {
+		fmt.Fprintf(&b, "\nnot started (interrupted): %s", strings.Join(notStarted, ", "))
+	}
+	return b.String()
+}

--- a/parallel_apply_test.go
+++ b/parallel_apply_test.go
@@ -3,6 +3,7 @@ package ecschedule
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -186,6 +187,73 @@ func TestRunParallelApplyExecFailureAggregates(t *testing.T) {
 	}
 	if !strings.Contains(out, "✅ rule \"rule-good\" applied") {
 		t.Errorf("successful rule block missing:\n%s", out)
+	}
+}
+
+// TestRunParallelApplyValidatesEachTaskDefinitionOnce pins the memoization
+// of task-definition validation. Real configs point many rules at a handful
+// of task definitions; without this, planning issues one identical
+// DescribeTaskDefinition per rule and ECS throttles the run before any
+// write happens (observed against a 150-rule config at -parallel 10).
+func TestRunParallelApplyValidatesEachTaskDefinitionOnce(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	captureLog(t)
+	var rules []*Rule
+	var names []string
+	for i := 0; i < 20; i++ {
+		name := fmt.Sprintf("rule-%02d", i)
+		ru := parallelTestRule(name)
+		if i >= 10 {
+			ru.TaskDefinition = "task2"
+		}
+		rules = append(rules, ru)
+		names = append(names, name)
+	}
+	c := parallelTestConfig(rules...)
+	if err := runParallelApply(context.Background(), stubAwsConfig(stub),
+		c, names, 10, diffFormatPrettyColored); err != nil {
+		t.Fatalf("parallel apply should succeed, got: %s", err)
+	}
+	describes := 0
+	for _, req := range stub.recorded() {
+		if req.target == "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition" {
+			describes++
+		}
+	}
+	if describes != 2 {
+		t.Errorf("DescribeTaskDefinition calls = %d, want 2: 20 rules share 2 task definitions", describes)
+	}
+}
+
+// TestApplyDryRunParallelValidatesEachTaskDefinitionOnce covers the same
+// amplification on the dry-run path, which does not go through
+// runParallelApply: it fans applyInternal out over executeJobsInParallel,
+// so the memoization has to be shared by the caller rather than created
+// per rule.
+func TestApplyDryRunParallelValidatesEachTaskDefinitionOnce(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	captureLog(t)
+	var rules []*Rule
+	for i := 0; i < 20; i++ {
+		rules = append(rules, parallelTestRule(fmt.Sprintf("rule-%02d", i)))
+	}
+	ctx := setApp(context.Background(), &app{
+		AccountID: "334",
+		AwsConf:   stubAwsConfig(stub),
+		Config:    parallelTestConfig(rules...),
+	})
+	err := cmdApply.Run(ctx, []string{"-all", "-dry-run", "-parallel", "10"}, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("dry-run should succeed, got: %s", err)
+	}
+	describes := 0
+	for _, req := range stub.recorded() {
+		if req.target == "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition" {
+			describes++
+		}
+	}
+	if describes != 1 {
+		t.Errorf("DescribeTaskDefinition calls = %d, want 1: 20 rules share one task definition", describes)
 	}
 }
 

--- a/parallel_apply_test.go
+++ b/parallel_apply_test.go
@@ -1,0 +1,209 @@
+package ecschedule
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func parallelTestConfig(rules ...*Rule) *Config {
+	return &Config{
+		BaseConfig: &BaseConfig{
+			Region:     "us-east-1",
+			Cluster:    "api",
+			AccountID:  "334",
+			TrackingID: "api",
+		},
+		Rules: rules,
+	}
+}
+
+func parallelTestRule(name string) *Rule {
+	ru := stubTestRule()
+	ru.Name = name
+	return ru
+}
+
+func TestFormatApplySummary(t *testing.T) {
+	failed := []jobOutcome[string]{
+		{Index: 0, Name: "job-a", Err: errors.New("PutTargets: AccessDenied")},
+	}
+	got := formatApplySummary(8, 2, failed, []string{"job-f", "job-g"})
+	want := "apply summary: 8 applied, 2 no change, 1 failed, 2 not started\n" +
+		"failed:\n" +
+		"  - job-a: PutTargets: AccessDenied\n" +
+		"not started (interrupted): job-f, job-g"
+	if got != want {
+		t.Errorf("summary mismatch\n got: %q\nwant: %q", got, want)
+	}
+	gotOK := formatApplySummary(3, 1, nil, nil)
+	wantOK := "apply summary: 3 applied, 1 no change, 0 failed, 0 not started"
+	if gotOK != wantOK {
+		t.Errorf("summary mismatch\n got: %q\nwant: %q", gotOK, wantOK)
+	}
+}
+
+func TestRunParallelApplyAppliesAllRules(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	buf := captureLog(t)
+	r1, r2 := parallelTestRule("rule-one"), parallelTestRule("rule-two")
+	r1.ContainerOverrides = []*ContainerOverride{
+		{Name: "container1", Environment: map[string]string{"FOO": "bar-env-value"}},
+	}
+	c := parallelTestConfig(r1, r2)
+	err := runParallelApply(context.Background(), stubAwsConfig(stub),
+		c, []string{"rule-one", "rule-two"}, 2, diffFormatPrettyColored)
+	if err != nil {
+		t.Fatalf("parallel apply should succeed, got: %s", err)
+	}
+	// PutTargets must carry the environment: display mutation happens
+	// only after execute returns for that rule.
+	var putTargetsBodies []string
+	putRules := 0
+	for _, req := range stub.recorded() {
+		switch req.target {
+		case "AWSEvents.PutTargets":
+			putTargetsBodies = append(putTargetsBodies, req.body)
+		case "AWSEvents.PutRule":
+			putRules++
+		}
+	}
+	if putRules != 2 {
+		t.Errorf("PutRule calls = %d, want 2", putRules)
+	}
+	found := false
+	for _, body := range putTargetsBodies {
+		if strings.Contains(body, "bar-env-value") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("PutTargets input lost the container-override environment")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "apply summary: 2 applied, 0 no change, 0 failed, 0 not started") {
+		t.Errorf("missing summary in output:\n%s", out)
+	}
+}
+
+func TestRunParallelApplyNoChangeCountsAsSuccess(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesMatch)}
+	buf := captureLog(t)
+	// stubTestRule matches the remote reconstruction → no diff
+	ru := parallelTestRule("test-rule")
+	c := parallelTestConfig(ru)
+	err := runParallelApply(context.Background(), stubAwsConfig(stub),
+		c, []string{"test-rule"}, 2, diffFormatPrettyColored)
+	if err != nil {
+		t.Fatalf("no-change run must return nil (prune gate), got: %s", err)
+	}
+	for _, req := range stub.recorded() {
+		if strings.HasPrefix(req.target, "AWSEvents.Put") || req.target == "AWSEvents.TagResource" {
+			t.Errorf("no-change rule must not be written: %s", req.target)
+		}
+	}
+	if !strings.Contains(buf.String(), "apply summary: 0 applied, 1 no change, 0 failed, 0 not started") {
+		t.Errorf("summary mismatch:\n%s", buf.String())
+	}
+}
+
+func TestRunParallelApplyValidationErrorBlocksAllWrites(t *testing.T) {
+	handlers := stubHandlers(listRulesEmpty)
+	handlers["AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition"] = func(body string) (int, string) {
+		if strings.Contains(body, "task-broken") {
+			return 400, `{"__type":"ClientException","message":"Unable to describe task definition."}`
+		}
+		return 200, `{"taskDefinition":{"taskDefinitionArn":"arn:aws:ecs:us-east-1:334:task-definition/task1:1"}}`
+	}
+	stub := &stubHTTPClient{handlers: handlers}
+	buf := captureLog(t)
+	good, bad := parallelTestRule("rule-good"), parallelTestRule("rule-bad")
+	bad.TaskDefinition = "task-broken"
+	c := parallelTestConfig(good, bad)
+	err := runParallelApply(context.Background(), stubAwsConfig(stub),
+		c, []string{"rule-good", "rule-bad"}, 2, diffFormatPrettyColored)
+	if err == nil {
+		t.Fatal("expected planning failure")
+	}
+	if !strings.Contains(err.Error(), "1 rule(s) failed validation/planning") {
+		t.Errorf("err = %s", err)
+	}
+	for _, req := range stub.recorded() {
+		if strings.HasPrefix(req.target, "AWSEvents.Put") || req.target == "AWSEvents.TagResource" {
+			t.Errorf("planning failure must block every write, but saw %s", req.target)
+		}
+	}
+	if !strings.Contains(buf.String(), `rule "rule-bad"`) {
+		t.Errorf("plan error must name the failing rule:\n%s", buf.String())
+	}
+}
+
+func TestRunParallelApplyPreCanceledCtxIsInterrupted(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	captureLog(t)
+	ru := parallelTestRule("rule-one")
+	c := parallelTestConfig(ru)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := runParallelApply(ctx, stubAwsConfig(stub),
+		c, []string{"rule-one"}, 2, diffFormatPrettyColored)
+	if err == nil {
+		t.Fatal("interrupted run must return an error (prune gate)")
+	}
+	if !strings.Contains(err.Error(), "interrupted") {
+		t.Errorf("err = %s", err)
+	}
+	if reqs := stub.recorded(); len(reqs) != 0 {
+		t.Errorf("no AWS call should happen when canceled before planning: %v", reqs)
+	}
+}
+
+func TestRunParallelApplyExecFailureAggregates(t *testing.T) {
+	handlers := stubHandlers(listRulesEmpty)
+	handlers["AWSEvents.PutTargets"] = func(body string) (int, string) {
+		if strings.Contains(body, "rule-bad") {
+			return 400, `{"__type":"AccessDeniedException","message":"denied"}`
+		}
+		return 200, `{"FailedEntryCount":0,"FailedEntries":[]}`
+	}
+	stub := &stubHTTPClient{handlers: handlers}
+	buf := captureLog(t)
+	good, bad := parallelTestRule("rule-good"), parallelTestRule("rule-bad")
+	c := parallelTestConfig(good, bad)
+	err := runParallelApply(context.Background(), stubAwsConfig(stub),
+		c, []string{"rule-good", "rule-bad"}, 2, diffFormatPrettyColored)
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if err.Error() != "1 rule(s) failed" {
+		t.Errorf("sentinel error = %q, want %q", err.Error(), "1 rule(s) failed")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "apply summary: 1 applied, 0 no change, 1 failed, 0 not started") {
+		t.Errorf("summary mismatch:\n%s", out)
+	}
+	if !strings.Contains(out, "✅ rule \"rule-good\" applied") {
+		t.Errorf("successful rule block missing:\n%s", out)
+	}
+}
+
+func TestApplyCmdParallelGuards(t *testing.T) {
+	captureLog(t)
+	ctx := setApp(context.Background(), &app{AccountID: "334"})
+	// parallel < 1 is still rejected
+	err := cmdApply.Run(ctx, []string{"-rule", "x", "-parallel", "0"}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "-parallel must be at least 1") {
+		t.Errorf("parallel=0 should be rejected, got: %v", err)
+	}
+	// parallel > 1 without -dry-run is no longer rejected up front
+	// (it fails later for a different reason: no config loaded).
+	err = cmdApply.Run(ctx, []string{"-rule", "x", "-parallel", "2"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected an error (no config), got nil")
+	}
+	if strings.Contains(err.Error(), "can only be used with -dry-run") {
+		t.Errorf("the dry-run-only guard must be removed, got: %v", err)
+	}
+}

--- a/parallel_continue_on_error_test.go
+++ b/parallel_continue_on_error_test.go
@@ -1,0 +1,175 @@
+package ecschedule
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func collectAll[T any](ch <-chan jobOutcome[T]) []jobOutcome[T] {
+	var outs []jobOutcome[T]
+	for out := range ch {
+		outs = append(outs, out)
+	}
+	return outs
+}
+
+func TestExecuteJobsInParallelContinueOnErrorAllSuccess(t *testing.T) {
+	names := []string{"a", "b", "c", "d"}
+	outs := collectAll(executeJobsInParallelContinueOnError(context.Background(), names, 2,
+		func(ctx context.Context, name string) (string, error) {
+			return "ok-" + name, nil
+		}))
+	if len(outs) != len(names) {
+		t.Fatalf("outcomes = %d, want %d", len(outs), len(names))
+	}
+	seen := map[int]jobOutcome[string]{}
+	for _, o := range outs {
+		seen[o.Index] = o
+	}
+	for i, name := range names {
+		o, ok := seen[i]
+		if !ok {
+			t.Fatalf("missing outcome for index %d", i)
+		}
+		if o.Name != name || o.Err != nil || o.Skipped || o.Result != "ok-"+name {
+			t.Errorf("outcome %d = %+v", i, o)
+		}
+	}
+}
+
+func TestExecuteJobsInParallelContinueOnErrorPartialFailureContinues(t *testing.T) {
+	names := []string{"a", "bad", "c"}
+	outs := collectAll(executeJobsInParallelContinueOnError(context.Background(), names, 2,
+		func(ctx context.Context, name string) (string, error) {
+			if name == "bad" {
+				return "", errors.New("boom")
+			}
+			return "ok", nil
+		}))
+	if len(outs) != 3 {
+		t.Fatalf("all jobs must be attempted; outcomes = %d", len(outs))
+	}
+	var failed, succeeded int
+	for _, o := range outs {
+		if o.Skipped {
+			t.Errorf("no job should be skipped without cancellation: %+v", o)
+		}
+		if o.Err != nil {
+			failed++
+		} else {
+			succeeded++
+		}
+	}
+	if failed != 1 || succeeded != 2 {
+		t.Errorf("failed=%d succeeded=%d, want 1/2", failed, succeeded)
+	}
+}
+
+func TestExecuteJobsInParallelContinueOnErrorPreCanceledCtxSkipsAll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ran := false
+	outs := collectAll(executeJobsInParallelContinueOnError(ctx, []string{"a", "b"}, 2,
+		func(ctx context.Context, name string) (string, error) {
+			ran = true
+			return "", nil
+		}))
+	if ran {
+		t.Error("jobFunc must not run when ctx is already canceled")
+	}
+	if len(outs) != 2 {
+		t.Fatalf("outcomes = %d, want 2 (exactly one per name even when skipped)", len(outs))
+	}
+	for _, o := range outs {
+		if !o.Skipped {
+			t.Errorf("outcome should be Skipped: %+v", o)
+		}
+	}
+}
+
+func TestExecuteJobsInParallelContinueOnErrorPanicRecordedWithStack(t *testing.T) {
+	outs := collectAll(executeJobsInParallelContinueOnError(context.Background(), []string{"a", "boom"}, 2,
+		func(ctx context.Context, name string) (string, error) {
+			if name == "boom" {
+				panic("kaboom")
+			}
+			return "ok", nil
+		}))
+	if len(outs) != 2 {
+		t.Fatalf("panic must still yield exactly one outcome per name; got %d", len(outs))
+	}
+	var panicked *jobOutcome[string]
+	for i := range outs {
+		if outs[i].Name == "boom" {
+			panicked = &outs[i]
+		}
+	}
+	if panicked == nil || panicked.Err == nil {
+		t.Fatal("panicking job must record an error")
+	}
+	msg := panicked.Err.Error()
+	if !strings.Contains(msg, "kaboom") {
+		t.Errorf("error should contain the panic value: %s", msg)
+	}
+	if !strings.Contains(msg, "goroutine") {
+		t.Errorf("error should embed the stack trace: %s", msg)
+	}
+}
+
+func TestExecuteJobsInParallelContinueOnErrorSequentialOrder(t *testing.T) {
+	var order []string
+	outs := collectAll(executeJobsInParallelContinueOnError(context.Background(), []string{"a", "b", "c"}, 1,
+		func(ctx context.Context, name string) (string, error) {
+			order = append(order, name) // safe: parallel=1 serializes jobs
+			return "", nil
+		}))
+	if strings.Join(order, ",") != "a,b,c" {
+		t.Errorf("parallel=1 must run jobs in names order: %v", order)
+	}
+	if len(outs) != 3 {
+		t.Errorf("outcomes = %d", len(outs))
+	}
+}
+
+func TestExecuteJobsInParallelContinueOnErrorReturnsImmediately(t *testing.T) {
+	// Verify that executeJobsInParallelContinueOnError returns immediately
+	// without blocking even when parallel=1 and the first job blocks.
+	blocker := make(chan struct{})
+	defer close(blocker)
+
+	// Call executeJobsInParallelContinueOnError; this should return
+	// immediately, not block even though the first job will block waiting on
+	// blocker channel.
+	ch := executeJobsInParallelContinueOnError(context.Background(), []string{"block", "b", "c"}, 1,
+		func(ctx context.Context, name string) (string, error) {
+			if name == "block" {
+				<-blocker // Block until test signals us
+			}
+			return "ok", nil
+		})
+
+	// Now: ch is open, but "block" hasn't delivered an outcome yet because
+	// it's still waiting on blocker. Try to receive with a timeout.
+	// If executeJobsInParallelContinueOnError had blocked in the caller,
+	// we'd be stuck here.
+	select {
+	case out := <-ch:
+		t.Errorf("should not have an outcome yet; got %+v", out)
+	case <-time.After(10 * time.Millisecond):
+		// Expected: channel open but no outcome ready yet
+	}
+
+	// Now unblock the first job and drain all outcomes
+	blocker <- struct{}{}
+
+	var outcomes []jobOutcome[string]
+	for out := range ch {
+		outcomes = append(outcomes, out)
+	}
+	if len(outcomes) != 3 {
+		t.Errorf("all jobs should complete; got %d outcomes", len(outcomes))
+	}
+}

--- a/rule.go
+++ b/rule.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -457,10 +458,10 @@ func (r *Rule) validateSSM() error {
 	return nil
 }
 
-func (r *Rule) validateTaskDefinition(ctx context.Context, awsConf aws.Config) error {
-	svc := ecs.NewFromConfig(awsConf, func(o *ecs.Options) {
+func (r *Rule) validateTaskDefinition(ctx context.Context, awsConf aws.Config, opts ...func(*ecs.Options)) error {
+	svc := ecs.NewFromConfig(awsConf, append([]func(*ecs.Options){func(o *ecs.Options) {
 		o.Region = r.Region
-	})
+	}}, opts...)...)
 	input := &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(r.Target.TaskDefinition),
 	}
@@ -468,6 +469,42 @@ func (r *Rule) validateTaskDefinition(ctx context.Context, awsConf aws.Config) e
 		return fmt.Errorf("task definition %s is not defined: %w", r.Target.TaskDefinition, err)
 	}
 	return nil
+}
+
+// taskDefValidator memoizes validateTaskDefinition per region + task
+// definition. Configs commonly point many rules at a handful of task
+// definitions; without memoization, planning issues one identical
+// DescribeTaskDefinition per rule, which is enough to throttle ECS at
+// parallel > 1 and abort the whole run before any write happens.
+type taskDefValidator struct {
+	opts    []func(*ecs.Options)
+	mu      sync.Mutex
+	entries map[string]*taskDefValidation
+}
+
+// taskDefValidation caches one outcome. The context error of whichever
+// caller wins the race is cached too, which is intended: every caller
+// shares the run's context, so a cancellation applies to all of them.
+type taskDefValidation struct {
+	once sync.Once
+	err  error
+}
+
+func newTaskDefValidator(opts ...func(*ecs.Options)) *taskDefValidator {
+	return &taskDefValidator{opts: opts, entries: map[string]*taskDefValidation{}}
+}
+
+func (v *taskDefValidator) validate(ctx context.Context, r *Rule, awsConf aws.Config) error {
+	key := r.Region + "\x00" + r.Target.TaskDefinition
+	v.mu.Lock()
+	e, ok := v.entries[key]
+	if !ok {
+		e = &taskDefValidation{}
+		v.entries[key] = e
+	}
+	v.mu.Unlock()
+	e.once.Do(func() { e.err = r.validateTaskDefinition(ctx, awsConf, v.opts...) })
+	return e.err
 }
 
 // Apply the rule (maintained for backward compatibility)
@@ -484,7 +521,7 @@ type applyPlan struct {
 
 // plan runs the validations and the remote diff for r. It performs no
 // writes and no logging; all output is returned as data.
-func (r *Rule) plan(ctx context.Context, awsConf aws.Config, svc *cloudwatchevents.Client, format diffFormat) (*applyPlan, error) {
+func (r *Rule) plan(ctx context.Context, awsConf aws.Config, svc *cloudwatchevents.Client, format diffFormat, tdv *taskDefValidator) (*applyPlan, error) {
 	if err := r.validateEnv(); err != nil {
 		return nil, err
 	}
@@ -494,7 +531,7 @@ func (r *Rule) plan(ctx context.Context, awsConf aws.Config, svc *cloudwatcheven
 	if err := r.validateSSM(); err != nil {
 		return nil, err
 	}
-	if err := r.validateTaskDefinition(ctx, awsConf); err != nil {
+	if err := tdv.validate(ctx, r, awsConf); err != nil {
 		return nil, err
 	}
 	from, to, err := r.diff(ctx, svc)
@@ -575,10 +612,17 @@ func (r *Rule) tagResourceWithRetry(ctx context.Context, svc *cloudwatchevents.C
 
 // applyInternal is the internal implementation with configurable diff format
 func (r *Rule) applyInternal(ctx context.Context, awsConf aws.Config, dryRun bool, format diffFormat) error {
+	return r.applyInternalWith(ctx, awsConf, dryRun, format, newTaskDefValidator())
+}
+
+// applyInternalWith lets a caller that applies several rules share one
+// taskDefValidator. Fanning applyInternal out over workers without sharing
+// one describes the same task definition once per rule.
+func (r *Rule) applyInternalWith(ctx context.Context, awsConf aws.Config, dryRun bool, format diffFormat, tdv *taskDefValidator) error {
 	svc := cloudwatchevents.NewFromConfig(awsConf, func(o *cloudwatchevents.Options) {
 		o.Region = r.Region
 	})
-	p, err := r.plan(ctx, awsConf, svc, format)
+	p, err := r.plan(ctx, awsConf, svc, format, tdv)
 	if err != nil {
 		return err
 	}

--- a/rule.go
+++ b/rule.go
@@ -3,11 +3,13 @@ package ecschedule
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
@@ -463,7 +465,7 @@ func (r *Rule) validateTaskDefinition(ctx context.Context, awsConf aws.Config) e
 		TaskDefinition: aws.String(r.Target.TaskDefinition),
 	}
 	if _, err := svc.DescribeTaskDefinition(ctx, input); err != nil {
-		return fmt.Errorf("task definition %s is not defined: %s", r.Target.TaskDefinition, err.Error())
+		return fmt.Errorf("task definition %s is not defined: %w", r.Target.TaskDefinition, err)
 	}
 	return nil
 }
@@ -473,53 +475,126 @@ func (r *Rule) Apply(ctx context.Context, awsConf aws.Config, dryRun bool) error
 	return r.applyInternal(ctx, awsConf, dryRun, diffFormatPrettyColored)
 }
 
-// applyInternal is the internal implementation with configurable diff format
-func (r *Rule) applyInternal(ctx context.Context, awsConf aws.Config, dryRun bool, format diffFormat) error {
+// applyPlan is the read-only result of planning one rule: whether the local
+// and remote definitions differ, and the pre-rendered diff output.
+type applyPlan struct {
+	hasChange  bool
+	diffOutput string
+}
+
+// plan runs the validations and the remote diff for r. It performs no
+// writes and no logging; all output is returned as data.
+func (r *Rule) plan(ctx context.Context, awsConf aws.Config, svc *cloudwatchevents.Client, format diffFormat) (*applyPlan, error) {
 	if err := r.validateEnv(); err != nil {
-		return err
+		return nil, err
 	}
 	if err := r.validateTFstate(); err != nil {
-		return err
+		return nil, err
 	}
 	if err := r.validateSSM(); err != nil {
-		return err
+		return nil, err
 	}
 	if err := r.validateTaskDefinition(ctx, awsConf); err != nil {
+		return nil, err
+	}
+	from, to, err := r.diff(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+	p := &applyPlan{hasChange: from != to}
+	if p.hasChange {
+		p.diffOutput = formatDiff(r.Name, from, to, format)
+	}
+	return p, nil
+}
+
+// perRuleApplyTimeout bounds one rule's write sequence. The sequence is
+// shielded from external cancellation (a sibling's failure or the first
+// SIGINT must not interrupt it mid-way), so this timeout is the only thing
+// guaranteeing liveness when an AWS call stalls.
+const perRuleApplyTimeout = 2 * time.Minute
+
+// tagResourceError reports that the rule was applied (PutRule/PutTargets
+// succeeded) but tagging failed. Error() returns exactly the underlying
+// error string so error output on the sequential path is unchanged;
+// callers that want to warn about the missing tracking-id tag detect it
+// with errors.As.
+type tagResourceError struct {
+	err        error
+	ruleARN    string
+	trackingID string
+}
+
+func (e *tagResourceError) Error() string { return e.err.Error() }
+func (e *tagResourceError) Unwrap() error { return e.err }
+
+// execute performs the write sequence PutRule → PutTargets → TagResource.
+func (r *Rule) execute(ctx context.Context, svc *cloudwatchevents.Client) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), perRuleApplyTimeout)
+	defer cancel()
+	if _, err := svc.PutRule(ctx, r.PutRuleInput()); err != nil {
 		return err
 	}
+	if _, err := svc.PutTargets(ctx, r.PutTargetsInput()); err != nil {
+		return err
+	}
+	if err := r.tagResourceWithRetry(ctx, svc); err != nil {
+		return &tagResourceError{err: err, ruleARN: r.ruleARN(), trackingID: r.TrackingID}
+	}
+	return nil
+}
+
+// tagResourceWithRetry retries TagResource up to 3 attempts, but only for
+// transient error classes the SDK retryer does not handle
+// (ConcurrentModificationException under concurrent bus writes, and
+// ResourceNotFoundException right after PutRule). Throttling errors are
+// already retried inside the SDK; adding app-level attempts on top of an
+// exhausted SDK retry only adds load.
+func (r *Rule) tagResourceWithRetry(ctx context.Context, svc *cloudwatchevents.Client) error {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(time.Duration(attempt) * 500 * time.Millisecond):
+			case <-ctx.Done():
+				return err
+			}
+		}
+		_, err = svc.TagResource(ctx, r.TagResourceInput())
+		if err == nil {
+			return nil
+		}
+		var concurrentMod *cweTypes.ConcurrentModificationException
+		var notFound *cweTypes.ResourceNotFoundException
+		if !errors.As(err, &concurrentMod) && !errors.As(err, &notFound) {
+			return err
+		}
+	}
+	return err
+}
+
+// applyInternal is the internal implementation with configurable diff format
+func (r *Rule) applyInternal(ctx context.Context, awsConf aws.Config, dryRun bool, format diffFormat) error {
 	svc := cloudwatchevents.NewFromConfig(awsConf, func(o *cloudwatchevents.Options) {
 		o.Region = r.Region
 	})
-
-	from, to, err := r.diff(ctx, svc)
+	p, err := r.plan(ctx, awsConf, svc, format)
 	if err != nil {
 		return err
 	}
-	if from == to {
+	if !p.hasChange {
 		log.Println("💡 skip applying. no differences")
 		return nil
 	}
-
 	var dryRunSuffix string
 	if dryRun {
 		dryRunSuffix = " (dry-run)"
 	}
-
-	diffOutput := formatDiff(r.Name, from, to, format)
-	log.Printf("💡 applying following changes%s\n%s", dryRunSuffix, diffOutput)
-
+	log.Printf("💡 applying following changes%s\n%s", dryRunSuffix, p.diffOutput)
 	if dryRun {
 		return nil
 	}
-	if _, err := svc.PutRule(ctx, r.PutRuleInput()); err != nil {
-		return err
-	}
-	if _, err = svc.PutTargets(ctx, r.PutTargetsInput()); err != nil {
-		return err
-	}
-	_, err = svc.TagResource(ctx, r.TagResourceInput())
-
-	return err
+	return r.execute(ctx, svc)
 }
 
 // Run the rule

--- a/rule_apply_stub_test.go
+++ b/rule_apply_stub_test.go
@@ -1,0 +1,336 @@
+package ecschedule
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
+)
+
+// stubHTTPClient satisfies aws.Config's HTTPClient interface and routes
+// requests by the X-Amz-Target header (awsjson 1.1 protocol used by both
+// CloudWatch Events and ECS). It records every request for assertions.
+type stubHTTPClient struct {
+	mu       sync.Mutex
+	handlers map[string]func(body string) (status int, respBody string)
+	requests []stubRequest
+}
+
+type stubRequest struct {
+	target string
+	body   string
+}
+
+func (s *stubHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	target := req.Header.Get("X-Amz-Target")
+	var body string
+	if req.Body != nil {
+		bs, _ := io.ReadAll(req.Body)
+		body = string(bs)
+	}
+	s.mu.Lock()
+	s.requests = append(s.requests, stubRequest{target: target, body: body})
+	h, ok := s.handlers[target]
+	s.mu.Unlock()
+	status, respBody := 400, `{"__type":"UnknownOperationException","message":"no stub handler"}`
+	if ok {
+		status, respBody = h(body)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/x-amz-json-1.1"}},
+		Body:       io.NopCloser(strings.NewReader(respBody)),
+	}, nil
+}
+
+func (s *stubHTTPClient) recorded() []stubRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]stubRequest(nil), s.requests...)
+}
+
+func stubAwsConfig(stub *stubHTTPClient) aws.Config {
+	return aws.Config{
+		Region: "us-east-1",
+		Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+			return aws.Credentials{AccessKeyID: "AKID", SecretAccessKey: "SECRET"}, nil
+		}),
+		HTTPClient:       stub,
+		RetryMaxAttempts: 1,
+	}
+}
+
+// stubTestRule returns a rule whose remote reconstruction from
+// listRulesMatch + the ListTargetsByRule stub is byte-identical to its
+// localYAMLForDiff, so diff yields from == to (the "no differences" case).
+func stubTestRule() *Rule {
+	return &Rule{
+		Name:               "test-rule",
+		ScheduleExpression: "cron(0 0 * * ? *)",
+		Target: &Target{
+			TaskDefinition: "task1",
+			Role:           "ecsEventsRole",
+		},
+		BaseConfig: &BaseConfig{
+			Region:     "us-east-1",
+			Cluster:    "api",
+			AccountID:  "334",
+			TrackingID: "api",
+		},
+	}
+}
+
+const (
+	listRulesMatch = `{"Rules":[{"Name":"test-rule","Arn":"arn:aws:events:us-east-1:334:rule/test-rule","ScheduleExpression":"cron(0 0 * * ? *)","State":"ENABLED"}]}`
+	listRulesEmpty = `{"Rules":[]}`
+)
+
+func stubHandlers(listRulesResp string) map[string]func(string) (int, string) {
+	return map[string]func(string) (int, string){
+		"AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition": func(string) (int, string) {
+			return 200, `{"taskDefinition":{"taskDefinitionArn":"arn:aws:ecs:us-east-1:334:task-definition/task1:1"}}`
+		},
+		"AWSEvents.ListRules": func(string) (int, string) {
+			return 200, listRulesResp
+		},
+		"AWSEvents.ListTargetsByRule": func(string) (int, string) {
+			return 200, `{"Targets":[{"Id":"test-rule","Arn":"arn:aws:ecs:us-east-1:334:cluster/api","RoleArn":"arn:aws:iam::334:role/ecsEventsRole","EcsParameters":{"TaskCount":1,"TaskDefinitionArn":"arn:aws:ecs:us-east-1:334:task-definition/task1"}}]}`
+		},
+		"AWSEvents.PutRule": func(string) (int, string) {
+			return 200, `{"RuleArn":"arn:aws:events:us-east-1:334:rule/test-rule"}`
+		},
+		"AWSEvents.PutTargets": func(string) (int, string) {
+			return 200, `{"FailedEntryCount":0,"FailedEntries":[]}`
+		},
+		"AWSEvents.TagResource": func(string) (int, string) {
+			return 200, `{}`
+		},
+	}
+}
+
+// captureLog redirects the global logger to a buffer with flags/prefix
+// normalized the way cmd/ecschedule/main.go + Run set them at runtime.
+// Tests using captureLog must not call t.Parallel(): the global logger is
+// process-wide state.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origFlags := log.Flags()
+	origPrefix := log.Prefix()
+	log.SetFlags(0)
+	log.SetPrefix("")
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetFlags(origFlags)
+		log.SetPrefix(origPrefix)
+		log.SetOutput(os.Stderr)
+	})
+	return &buf
+}
+
+func TestApplyGoldenLogNoDiff(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesMatch)}
+	buf := captureLog(t)
+	ru := stubTestRule()
+	if err := ru.Apply(context.Background(), stubAwsConfig(stub), false); err != nil {
+		t.Fatal(err)
+	}
+	want := "💡 skip applying. no differences\n"
+	if got := buf.String(); got != want {
+		t.Errorf("golden log mismatch\n got: %q\nwant: %q", got, want)
+	}
+	for _, req := range stub.recorded() {
+		if strings.HasPrefix(req.target, "AWSEvents.Put") || req.target == "AWSEvents.TagResource" {
+			t.Errorf("no-diff apply must not write, but called %s", req.target)
+		}
+	}
+}
+
+// canceledHTTPClient simulates the behavior of net/http.Client.Do when the
+// request's context is already canceled at call time: it returns the
+// context's error instead of a response. This lets us exercise the same
+// smithy-go path (RequestSendError overridden with smithy.CanceledError)
+// that a real SIGINT-during-DescribeTaskDefinition would take, without any
+// real network I/O or timing dependency.
+type canceledHTTPClient struct{}
+
+func (canceledHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("canceledHTTPClient: request context was not canceled")
+}
+
+// TestValidateTaskDefinitionPreservesContextCanceled proves the %w wrap in
+// validateTaskDefinition keeps the error chain intact, so
+// errors.Is(err, context.Canceled) still holds after wrapping. This is what
+// parallel_apply.go's Phase-1 classification relies on to report a SIGINT
+// during planning as "interrupted", not as a validation failure.
+func TestValidateTaskDefinitionPreservesContextCanceled(t *testing.T) {
+	r := stubTestRule()
+	awsConf := stubAwsConfig(&stubHTTPClient{})
+	awsConf.HTTPClient = canceledHTTPClient{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.validateTaskDefinition(ctx, awsConf)
+	if err == nil {
+		t.Fatal("expected an error when the context is already canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(err, context.Canceled) = false, want true (error chain broken); err: %v", err)
+	}
+}
+
+// logLine mimics log.Output: appends a newline only when missing.
+func logLine(s string) string {
+	if strings.HasSuffix(s, "\n") {
+		return s
+	}
+	return s + "\n"
+}
+
+func TestApplyGoldenLogDiffDryRun(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	buf := captureLog(t)
+	ru := stubTestRule()
+	if err := ru.Apply(context.Background(), stubAwsConfig(stub), true); err != nil {
+		t.Fatal(err)
+	}
+	localYaml, err := ru.localYAMLForDiff()
+	if err != nil {
+		t.Fatal(err)
+	}
+	diffOut := formatDiff("test-rule", "", localYaml, diffFormatPrettyColored)
+	want := logLine(fmt.Sprintf("💡 applying following changes (dry-run)\n%s", diffOut))
+	if got := buf.String(); got != want {
+		t.Errorf("golden log mismatch\n got: %q\nwant: %q", got, want)
+	}
+	for _, req := range stub.recorded() {
+		if strings.HasPrefix(req.target, "AWSEvents.Put") || req.target == "AWSEvents.TagResource" {
+			t.Errorf("dry-run must not write, but called %s", req.target)
+		}
+	}
+}
+
+func TestApplyGoldenLogDiffRealApply(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	buf := captureLog(t)
+	ru := stubTestRule()
+	if err := ru.Apply(context.Background(), stubAwsConfig(stub), false); err != nil {
+		t.Fatal(err)
+	}
+	localYaml, err := ru.localYAMLForDiff()
+	if err != nil {
+		t.Fatal(err)
+	}
+	diffOut := formatDiff("test-rule", "", localYaml, diffFormatPrettyColored)
+	want := logLine(fmt.Sprintf("💡 applying following changes\n%s", diffOut))
+	if got := buf.String(); got != want {
+		t.Errorf("golden log mismatch\n got: %q\nwant: %q", got, want)
+	}
+	var wrote []string
+	for _, req := range stub.recorded() {
+		if strings.HasPrefix(req.target, "AWSEvents.Put") || req.target == "AWSEvents.TagResource" {
+			wrote = append(wrote, req.target)
+		}
+	}
+	wantCalls := []string{"AWSEvents.PutRule", "AWSEvents.PutTargets", "AWSEvents.TagResource"}
+	if strings.Join(wrote, ",") != strings.Join(wantCalls, ",") {
+		t.Errorf("write calls = %v, want %v", wrote, wantCalls)
+	}
+}
+
+func TestApplyPutTargetsKeepsEnvironment(t *testing.T) {
+	stub := &stubHTTPClient{handlers: stubHandlers(listRulesEmpty)}
+	captureLog(t)
+	ru := stubTestRule()
+	ru.ContainerOverrides = []*ContainerOverride{
+		{Name: "container1", Environment: map[string]string{"FOO": "bar-env-value"}},
+	}
+	if err := ru.Apply(context.Background(), stubAwsConfig(stub), false); err != nil {
+		t.Fatal(err)
+	}
+	var putTargetsBody string
+	for _, req := range stub.recorded() {
+		if req.target == "AWSEvents.PutTargets" {
+			putTargetsBody = req.body
+		}
+	}
+	if putTargetsBody == "" {
+		t.Fatal("PutTargets was not called")
+	}
+	if !strings.Contains(putTargetsBody, "bar-env-value") {
+		t.Errorf("PutTargets input lost the container-override environment: %s", putTargetsBody)
+	}
+}
+
+func TestExecuteRetriesConcurrentModification(t *testing.T) {
+	var calls int
+	handlers := stubHandlers(listRulesEmpty)
+	handlers["AWSEvents.TagResource"] = func(string) (int, string) {
+		calls++
+		if calls < 3 {
+			return 400, `{"__type":"ConcurrentModificationException","message":"concurrent modification"}`
+		}
+		return 200, `{}`
+	}
+	stub := &stubHTTPClient{handlers: handlers}
+	captureLog(t)
+	ru := stubTestRule()
+	svc := cloudwatchevents.NewFromConfig(stubAwsConfig(stub), func(o *cloudwatchevents.Options) {
+		o.Region = ru.Region
+	})
+	if err := ru.execute(context.Background(), svc); err != nil {
+		t.Fatalf("execute should succeed after retries, got: %s", err)
+	}
+	if calls != 3 {
+		t.Errorf("TagResource calls = %d, want 3", calls)
+	}
+}
+
+func TestExecuteTagFailureReturnsDedicatedError(t *testing.T) {
+	var calls int
+	handlers := stubHandlers(listRulesEmpty)
+	handlers["AWSEvents.TagResource"] = func(string) (int, string) {
+		calls++
+		return 400, `{"__type":"AccessDeniedException","message":"denied"}`
+	}
+	stub := &stubHTTPClient{handlers: handlers}
+	captureLog(t)
+	ru := stubTestRule()
+	svc := cloudwatchevents.NewFromConfig(stubAwsConfig(stub), func(o *cloudwatchevents.Options) {
+		o.Region = ru.Region
+	})
+	err := ru.execute(context.Background(), svc)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("non-retryable tag error should not be retried at app level: calls = %d, want 1", calls)
+	}
+	var tagErr *tagResourceError
+	if !errors.As(err, &tagErr) {
+		t.Fatalf("error should be *tagResourceError, got %T: %s", err, err)
+	}
+	if tagErr.Error() != tagErr.err.Error() {
+		t.Errorf("tagResourceError.Error() must equal the wrapped error string\n got: %q\nwant: %q", tagErr.Error(), tagErr.err.Error())
+	}
+	if tagErr.ruleARN != "arn:aws:events:us-east-1:334:rule/test-rule" {
+		t.Errorf("ruleARN = %q", tagErr.ruleARN)
+	}
+	if tagErr.trackingID != "api" {
+		t.Errorf("trackingID = %q", tagErr.trackingID)
+	}
+}


### PR DESCRIPTION
## Summary

`-parallel` currently only speeds up `diff` and `apply -dry-run`; a real `apply` always runs sequentially. This PR makes `apply -parallel N` (N > 1) run for real, through a three-phase plan → execute → summarize path that is deliberately more conservative than the sequential path.

`-parallel 1` (the default) and `-dry-run` keep their existing code paths and byte-identical output — golden-log tests in this PR pin that.

## ⚠️ BREAKING CHANGE: duplicate rule names are rejected at load time

**A config containing two rules with the same name no longer loads, for every subcommand, at any `-parallel` value.** Configs that are valid today can start failing after this change.

It is deliberate rather than incidental. `GetRuleByName` resolves a name to the first match, so duplicates already caused two bugs: later rules were silently shadowed in sequential apply, and — worse — the *same* `*Rule` pointer was handed to several workers at once in the existing parallel `diff` / `apply -dry-run`, which is a data race. Making the new parallel apply safe means the duplicates have to be rejected rather than tolerated.

The error names the offending rule. Fixing a config means renaming the duplicate or regenerating with `ecschedule dump`.

## How it works

```mermaid
sequenceDiagram
    autonumber
    participant M as runParallelApply
    participant W as workers<br/>(at most N in flight)
    participant AWS

    Note over M,AWS: Phase 1 — plan · read-only · N rules at a time
    M->>W: admit a rule (blocks while N are in flight)
    W->>AWS: DescribeTaskDefinition (memoized per task definition)
    W->>AWS: ListRules / ListTargetsByRule
    W-->>M: plan: differs? + rendered diff
    Note over M: BARRIER — every rule is planned before any write.<br/>One failure ⇒ report them all, exit 1, nothing written.

    Note over M,AWS: Phase 2 — execute · only rules that differ · N at a time
    M->>W: admit a changed rule
    rect rgba(127, 127, 127, 0.2)
    Note over W,AWS: ATOMIC per rule — a sibling's failure or the<br/>first Ctrl-C cannot interrupt this sequence<br/>(context.WithoutCancel + 2 min timeout)
    W->>AWS: PutRule
    W->>AWS: PutTargets
    W->>AWS: TagResource
    end
    W-->>M: outcome: applied / failed (never cancels siblings)
    Note over M: each rule's result is one indivisible log block,<br/>so results never interleave

    Note over M: Phase 3 — summary.<br/>prune runs only if every rule succeeded and nothing was interrupted.
```

**Phase 1 — plan (read-only).** Every rule is validated (env / tfstate / ssm placeholders, task definition existence) and diffed against the remote. No writes happen until every rule has passed. If any rule fails validation, all of them are reported and nothing is written — a bad config can no longer leave the account half-applied.

**Phase 2 — execute.** Only rules that actually differ are written, continue-on-error, with per-region clients (`RetryMaxAttempts=10`). Each rule's *result* — its diff plus the resulting YAML — is emitted as a single indivisible block, so results never interleave; the short `applying rule "..."` progress lines are separate and do appear between those blocks. A rule that has started writing always finishes its `PutRule` → `PutTargets` → `TagResource` sequence: the sequence runs under `context.WithoutCancel` plus a 2-minute timeout, so a sibling's failure — or the first Ctrl-C — can never interrupt a half-written rule, while a stalled AWS call still cannot hang the run forever.

**Phase 3 — summary.** Applied / failed / skipped counts, with the failures listed. `runParallelApply` returns nil only on full uninterrupted success, and that is what gates the `-prune` block, so pruning never runs on a partial result.

## Behavior changes worth calling out

Besides the breaking change above:

- **SIGINT/SIGTERM are now handled** — **all subcommands, any `-parallel` value.** Previously nothing caught them, so a Ctrl-C during `apply` killed the process outright and could leave a rule with `PutRule` applied and `PutTargets` not. Now the first signal stops work at API-call boundaries, a rule that has already begun writing runs to completion, and the command exits 1 through the normal error path instead of dying to the signal (previously ~130). A second signal restores default fatal handling as an escape hatch.
- **Tag-only failures are reported distinctly** — **`apply -parallel > 1` only.** When `PutRule`/`PutTargets` succeeded but `TagResource` did not, the failure prints a fully substituted `aws events tag-resource` repair command, because a re-run does not heal it. `-parallel 1` keeps its existing error output byte for byte.

## Caveat introduced by this PR

- The SDK retry budget is shared per region rather than per rule, so under sustained failures at `-parallel > 1` some rules may surface a rate-limit-token error instead of the underlying one — two error texts for a single root cause. Documented in the README.

## Two parallel runners, for now

`executeJobsInParallelContinueOnError` joins the existing `executeJobsInParallel` rather than replacing it, because the two differ in exactly one way that matters: the existing one shares an `errgroup.WithContext`, so the first error cancels the rest, while apply needs every rule attempted and the failures aggregated.

The split is not meant to be permanent, and the doc comment says so. `executeJobsInParallelContinueOnError` is the more general of the two — fail-fast can be layered on it by cancelling a derived context on the first error, while the reverse is not possible — so it is the consolidation target. The reason the remaining callers (`diff` and `apply -dry-run`) are not moved here is that it would change what they report, from only the first error to every rule's, and that behavior change does not belong in this PR.

## Also fixed here: one DescribeTaskDefinition per rule

Planning validated the task definition once per rule, so a config where many rules share a task definition issued that many identical `DescribeTaskDefinition` calls. At `-parallel 10` over 150 rules that is enough for ECS to answer `ThrottlingException`, and since planning is fail-closed the whole run aborted with a message blaming a task definition that exists. The last commit memoizes the result per region + task definition (so 150 calls become 1) and gives planning the same raised retry budget as the write phase. The dry-run and `diff -validate` parallel paths share the same memoization.

## Testing

- Golden-log tests stub AWS at the HTTP layer and pin `apply`'s exact log output and call sequence, so "the `-parallel 1` path is unchanged" is enforced rather than asserted.
- Exercised against real AWS with a 150-rule config: fail-closed planning (confirmed remotely that nothing was written), a full apply followed by an idempotent re-run, the first Ctrl-C leaving no half-written rule, the tag-only failure path, and `-prune` deleting exactly the orphans.

The commits are ordered so each one builds and tests green on its own.

## Pre-existing issues this PR does not address

Neither is introduced or changed by this PR, and neither is fixed here. They are listed only because applying many rules at once makes them easier to run into, and both look worth separate fixes.

- `-prune` orphan detection only searches the region of the ambient AWS configuration, so rules under a per-rule `region` override are outside its view.
- Changing a `targetId` leaves the old target attached remotely: the rule then fires both targets and subsequently diffs as a new rule.
